### PR TITLE
Use INFOPLIST_PATH rather than PRODUCT_SETTINGS_PATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ with zipfile.ZipFile(zip_location, 'w') as zipf:
 
 info_file_path = os.path.join(os.environ['INSTALL_DIR'], os.environ['INFOPLIST_PATH'])
 p = subprocess.Popen('/usr/libexec/PlistBuddy -c "Print :CFBundleVersion" -c "Print :CFBundleIdentifier" "%s"' % info_file_path,
-stdout=subprocess.PIPE, shell=True)
+                     stdout=subprocess.PIPE, shell=True)
 
 stdout, stderr = p.communicate()
 version, identifier = stdout.split()

--- a/README.md
+++ b/README.md
@@ -150,8 +150,10 @@ with zipfile.ZipFile(zip_location, 'w') as zipf:
         for f in files:
             zipf.write(os.path.join(root, f))
 
-p = subprocess.Popen('/usr/libexec/PlistBuddy -c "Print :CFBundleVersion" -c "Print :CFBundleIdentifier" "%s"' % os.environ['PRODUCT_SETTINGS_PATH'],
-                     stdout=subprocess.PIPE, shell=True)
+info_file_path = os.path.join(os.environ['INSTALL_DIR'], os.environ['INFOPLIST_PATH'])
+p = subprocess.Popen('/usr/libexec/PlistBuddy -c "Print :CFBundleVersion" -c "Print :CFBundleIdentifier" "%s"' % info_file_path,
+stdout=subprocess.PIPE, shell=True)
+
 stdout, stderr = p.communicate()
 version, identifier = stdout.split()
 


### PR DESCRIPTION
The original script doesn't properly deal with XCode placeholders, e.g. ```$(PRODUCT_NAME:rfc1034identifier)``` in the ```PRODUCT_SETTINGS_PATH``` variable. Instead, use ```INFOPLIST_PATH```, which is relative to ```INSTALL_DIR```. This points to a compiled info.plist file that has the correct identifier.
