### PR TITLE
Add flag for enabling crash reporter

### DIFF
--- a/Rollbar/Rollbar.h
+++ b/Rollbar/Rollbar.h
@@ -11,6 +11,8 @@
 
 @interface Rollbar : NSObject
 
++ (void)initWithAccessToken:(NSString*)accessToken configuration:(RollbarConfiguration*)configuration
+        enableCrashReporter:(BOOL)enable;
 + (void)initWithAccessToken:(NSString*)accessToken;
 + (void)initWithAccessToken:(NSString*)accessToken configuration:(RollbarConfiguration*)configuration;
 

--- a/Rollbar/Rollbar.m
+++ b/Rollbar/Rollbar.m
@@ -55,12 +55,19 @@ static RollbarNotifier *notifier = nil;
 }
 
 + (void)initWithAccessToken:(NSString *)accessToken configuration:(RollbarConfiguration*)configuration {
+    [self initWithAccessToken:accessToken configuration:configuration enableCrashReporter:YES];
+}
+
++ (void)initWithAccessToken:(NSString *)accessToken configuration:(RollbarConfiguration*)configuration
+        enableCrashReporter:(BOOL)enable {
     if (notifier) {
         RollbarLog(@"Rollbar has already been initialized.");
     } else {
         notifier = [[RollbarNotifier alloc] initWithAccessToken:accessToken configuration:configuration isRoot:YES];
-        
-        [self enableCrashReporter];
+
+        if (enable) {
+            [self enableCrashReporter];
+        }
         
         [notifier.configuration save];
     }


### PR DESCRIPTION
This is allows the developers to use a crash reporter from a different vendor if they choose to do so.