### PR TITLE
Add support for custom data to be send along with logs and crash reports

### DIFF
--- a/Rollbar/RollbarConfiguration.h
+++ b/Rollbar/RollbarConfiguration.h
@@ -23,6 +23,8 @@
 
 - (void)setPersonId:(NSString*)personId username:(NSString*)username email:(NSString*)email;
 
+- (NSDictionary *)customData;
+
 @property (atomic, copy) NSString *accessToken;
 @property (atomic, copy) NSString *environment;
 @property (atomic, copy) NSString *endpoint;

--- a/Rollbar/RollbarNotifier.m
+++ b/Rollbar/RollbarNotifier.m
@@ -236,6 +236,8 @@ static BOOL isNetworkReachable = YES;
     NSDictionary *notifierData = @{@"name": @"rollbar-ios",
                                    @"version": NOTIFIER_VERSION};
     
+    NSDictionary *customData = self.configuration.customData;
+    
     NSDictionary *body = [self buildPayloadBodyWithMessage:message exception:exception extra:extra crashReport:crashReport];
     
     NSMutableDictionary *data = [@{@"environment": self.configuration.environment,
@@ -246,6 +248,7 @@ static BOOL isNetworkReachable = YES;
                                    @"uuid": [self generateUUID],
                                    @"client": clientData,
                                    @"notifier": notifierData,
+                                   @"custom": customData,
                                    @"body": body} mutableCopy];
     
     NSDictionary *personData = [self buildPersonData];


### PR DESCRIPTION
This change adds support for arbitrary pairs of keys and values to be added to RollbarConfig by calling -[RollbarConfig setValue:(id)value forKey:(NSString)* key]. The data is saved to disk whenever it is changed and loaded from the cache if a new instance of RollbarConfig is initialized with -initWithLoadedConfiguration. Custom data is send along with any log or crash report.

A value can be removed by calling -setValue:forKey: with a nil value.