### PR TITLE
Crash fix

### DIFF
--- a/Rollbar/RollbarNotifier.m
+++ b/Rollbar/RollbarNotifier.m
@@ -266,7 +266,8 @@ static BOOL isNetworkReachable = YES;
 }
 
 - (NSDictionary*)buildPayloadBodyWithMessage:(NSString*)message extra:(NSDictionary*)extra {
-    NSMutableDictionary *result = [@{@"body": message} mutableCopy];
+    NSMutableDictionary *result = [NSMutableDictionary dictionary];
+    result[@"body"] = message ? message : @"";
     
     if (extra) {
         result[@"extra"] = extra;


### PR DESCRIPTION
Add a nil check since the following functions pass message=nil down to  `buildPayloadBodyWithMessage`

+ [Rollbar logWithLevel:data:]
+ [Rollbar debugWithData:]
+ [Rollbar infoWithData:]
+ [Rollbar warningWithData:]
+ [Rollbar errorWithData:]
+ [Rollbar criticalWithData:]
- [RollbarNotifier logCrashReport:]
