### PR TITLE
Fix error "Include of non-modular header inside framework module 'Rol…

### DIFF
--- a/Rollbar/RollbarReachability.h
+++ b/Rollbar/RollbarReachability.h
@@ -28,13 +28,6 @@
 #import <Foundation/Foundation.h>
 #import <SystemConfiguration/SystemConfiguration.h>
 
-#import <sys/socket.h>
-#import <netinet/in.h>
-#import <netinet6/in6.h>
-#import <arpa/inet.h>
-#import <ifaddrs.h>
-#import <netdb.h>
-
 /**
  * Does ARC support GCD objects?
  * It does if the minimum deployment target is iOS 6+ or Mac OS X 8+

--- a/Rollbar/RollbarReachability.m
+++ b/Rollbar/RollbarReachability.m
@@ -27,6 +27,12 @@
 
 #import "RollbarReachability.h"
 
+#import <sys/socket.h>
+#import <netinet/in.h>
+#import <netinet6/in6.h>
+#import <arpa/inet.h>
+#import <ifaddrs.h>
+#import <netdb.h>
 
 NSString *const kRollbarReachabilityChangedNotification = @"kRollbarReachabilityChangedNotification";
 


### PR DESCRIPTION
…lbar.RollbarReachability'" when using Rollbar in a swift application.