### PR TITLE
Handle localized bundle names

### DIFF
--- a/Rollbar/RollbarNotifier.m
+++ b/Rollbar/RollbarNotifier.m
@@ -205,12 +205,12 @@ static BOOL isNetworkReachable = YES;
 - (NSDictionary*)buildClientData {
     NSNumber *timestamp = [NSNumber numberWithInteger:[[NSDate date] timeIntervalSince1970]]
     ;
-    NSDictionary *infoDictionary = [[NSBundle mainBundle]infoDictionary];
+    NSBundle *mainBundle = [NSBundle mainBundle];
     
-    NSString *version = infoDictionary[(NSString*)kCFBundleVersionKey];
-    NSString *shortVersion = infoDictionary[@"CFBundleShortVersionString"];
-    NSString *bundleName = infoDictionary[(NSString *)kCFBundleNameKey];
-    NSString *bundleIdentifier = infoDictionary[(NSString *)kCFBundleIdentifierKey];
+    NSString *version = [mainBundle objectForInfoDictionaryKey:(NSString*)kCFBundleVersionKey];
+    NSString *shortVersion = [mainBundle objectForInfoDictionaryKey:@"CFBundleShortVersionString"];
+    NSString *bundleName = [mainBundle objectForInfoDictionaryKey:(NSString *)kCFBundleNameKey];
+    NSString *bundleIdentifier = [mainBundle objectForInfoDictionaryKey:(NSString *)kCFBundleIdentifierKey];
     
     struct utsname systemInfo;
     uname(&systemInfo);


### PR DESCRIPTION
For apps that localize their bundle name in InfoPlist.strings, [[NSBundle mainBundle] infoDictionary] will not contain the key CFBundleName and the app crashes when trying to add the nil bundleName to the iosData dictionary. This fix checks whether the name is nil and, if it is, retrieves it from [[NSBundle mainBundle] localizedInfoDictionary] instead.