### PR TITLE
Fix umbrella header errors for Carthage support

### DIFF
--- a/Rollbar.xcodeproj/project.pbxproj
+++ b/Rollbar.xcodeproj/project.pbxproj
@@ -96,6 +96,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		289DD6CB1DB6DE54004C03D1 /* Rollbar.modulemap */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = "sourcecode.module-map"; path = Rollbar.modulemap; sourceTree = "<group>"; };
 		343AB4521CC9AAE600962943 /* Rollbar.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Rollbar.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		343AB4541CC9AAE600962943 /* RollbarFramework.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RollbarFramework.h; sourceTree = "<group>"; };
 		343AB4561CC9AAE600962943 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -164,6 +165,7 @@
 			children = (
 				343AB4541CC9AAE600962943 /* RollbarFramework.h */,
 				343AB4561CC9AAE600962943 /* Info.plist */,
+				289DD6CB1DB6DE54004C03D1 /* Rollbar.modulemap */,
 			);
 			path = RollbarFramework;
 			sourceTree = "<group>";
@@ -535,6 +537,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MODULEMAP_FILE = RollbarFramework/Rollbar.modulemap;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.rollbar.Rollbar;
 				PRODUCT_NAME = Rollbar;
@@ -569,6 +572,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MODULEMAP_FILE = RollbarFramework/Rollbar.modulemap;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = com.rollbar.Rollbar;
 				PRODUCT_NAME = Rollbar;

--- a/RollbarFramework/Rollbar.modulemap
+++ b/RollbarFramework/Rollbar.modulemap
@@ -1,0 +1,6 @@
+framework module Rollbar {
+    umbrella header "RollbarFramework.h"
+
+    export *
+    module * { export * }
+}

--- a/RollbarFramework/RollbarFramework.h
+++ b/RollbarFramework/RollbarFramework.h
@@ -8,10 +8,10 @@ FOUNDATION_EXPORT const unsigned char RollbarFrameworkVersionString[];
 
 @import CrashReporter;
 
-#import <RollbarFramework/Rollbar.h>
-#import <RollbarFramework/RollbarNotifier.h>
-#import <RollbarFramework/RollbarConfiguration.h>
-#import <RollbarFramework/RollbarThread.h>
-#import <RollbarFramework/RollbarFileReader.h>
-#import <RollbarFramework/RollbarReachability.h>
-#import <RollbarFramework/RollbarLogger.h>
+#import <Rollbar/Rollbar.h>
+#import <Rollbar/RollbarNotifier.h>
+#import <Rollbar/RollbarConfiguration.h>
+#import <Rollbar/RollbarThread.h>
+#import <Rollbar/RollbarFileReader.h>
+#import <Rollbar/RollbarReachability.h>
+#import <Rollbar/RollbarLogger.h>


### PR DESCRIPTION
Fixes 
![screenshot 2016-10-18 15 50 22](https://cloud.githubusercontent.com/assets/54970/19499806/41536aa4-954d-11e6-9b3f-b4c1c00dd7a9.png)

when importing framework built by Carthage.
