### PR TITLE
Support sending context with occurrences

### DIFF
--- a/Rollbar/Rollbar.h
+++ b/Rollbar/Rollbar.h
@@ -20,6 +20,8 @@
 
 + (void)logWithLevel:(NSString*)level message:(NSString*)message;
 + (void)logWithLevel:(NSString*)level message:(NSString*)message data:(NSDictionary*)data;
++ (void)logWithLevel:(NSString*)level message:(NSString*)message data:(NSDictionary*)data context:(NSString*)context;
+
 + (void)logWithLevel:(NSString*)level data:(NSDictionary*)data;
 
 + (void)debugWithMessage:(NSString*)message;

--- a/Rollbar/Rollbar.m
+++ b/Rollbar/Rollbar.m
@@ -80,85 +80,89 @@ static RollbarNotifier *notifier = nil;
 // Log
 
 + (void)logWithLevel:(NSString*)level message:(NSString*)message {
-    [notifier log:level message:message exception:nil data:nil];
+    [notifier log:level message:message exception:nil data:nil context:nil];
 }
 
 + (void)logWithLevel:(NSString*)level message:(NSString*)message data:(NSDictionary*)data {
-    [notifier log:level message:message exception:nil data:data];
+    [notifier log:level message:message exception:nil data:data context:nil];
+}
+
++ (void)logWithLevel:(NSString*)level message:(NSString*)message data:(NSDictionary*)data context:(NSString*)context {
+    [notifier log:level message:message exception:nil data:data context:context];
 }
 
 + (void)logWithLevel:(NSString*)level data:(NSDictionary*)data {
-    [notifier log:level message:nil exception:nil data:data];
+    [notifier log:level message:nil exception:nil data:data context:nil];
 }
 
 // Debug
 
 + (void)debugWithMessage:(NSString*)message {
-    [notifier log:@"debug" message:message exception:nil data:nil];
+    [notifier log:@"debug" message:message exception:nil data:nil context:nil];
 }
 
 + (void)debugWithMessage:(NSString*)message data:(NSDictionary*)data {
-    [notifier log:@"debug" message:message exception:nil data:data];
+    [notifier log:@"debug" message:message exception:nil data:data context:nil];
 }
 
 + (void)debugWithData:(NSDictionary*)data {
-    [notifier log:@"debug" message:nil exception:nil data:data];
+    [notifier log:@"debug" message:nil exception:nil data:data context:nil];
 }
 
 // Info
 
 + (void)infoWithMessage:(NSString*)message {
-    [notifier log:@"info" message:message exception:nil data:nil];
+    [notifier log:@"info" message:message exception:nil data:nil context:nil];
 }
 
 + (void)infoWithMessage:(NSString*)message data:(NSDictionary*)data {
-    [notifier log:@"info" message:message exception:nil data:data];
+    [notifier log:@"info" message:message exception:nil data:data context:nil];
 }
 
 + (void)infoWithData:(NSDictionary*)data {
-    [notifier log:@"info" message:nil exception:nil data:data];
+    [notifier log:@"info" message:nil exception:nil data:data context:nil];
 }
 
 // Warning
 
 + (void)warningWithMessage:(NSString*)message {
-    [notifier log:@"warning" message:message exception:nil data:nil];
+    [notifier log:@"warning" message:message exception:nil data:nil context:nil];
 }
 
 + (void)warningWithMessage:(NSString*)message data:(NSDictionary*)data {
-    [notifier log:@"warning" message:message exception:nil data:data];
+    [notifier log:@"warning" message:message exception:nil data:data context:nil];
 }
 
 + (void)warningWithData:(NSDictionary*)data {
-    [notifier log:@"warning" message:nil exception:nil data:data];
+    [notifier log:@"warning" message:nil exception:nil data:data context:nil];
 }
 
 // Error
 
 + (void)errorWithMessage:(NSString*)message {
-    [notifier log:@"error" message:message exception:nil data:nil];
+    [notifier log:@"error" message:message exception:nil data:nil context:nil];
 }
 
 + (void)errorWithMessage:(NSString*)message data:(NSDictionary*)data {
-    [notifier log:@"error" message:message exception:nil data:data];
+    [notifier log:@"error" message:message exception:nil data:data context:nil];
 }
 
 + (void)errorWithData:(NSDictionary*)data {
-    [notifier log:@"error" message:nil exception:nil data:data];
+    [notifier log:@"error" message:nil exception:nil data:data context:nil];
 }
 
 // Critical
 
 + (void)criticalWithMessage:(NSString*)message {
-    [notifier log:@"critical" message:message exception:nil data:nil];
+    [notifier log:@"critical" message:message exception:nil data:nil context:nil];
 }
 
 + (void)criticalWithMessage:(NSString*)message data:(NSDictionary*)data {
-    [notifier log:@"critical" message:message exception:nil data:data];
+    [notifier log:@"critical" message:message exception:nil data:data context:nil];
 }
 
 + (void)criticalWithData:(NSDictionary*)data {
-    [notifier log:@"critical" message:nil exception:nil data:data];
+    [notifier log:@"critical" message:nil exception:nil data:data context:nil];
 }
 
 @end

--- a/Rollbar/RollbarNotifier.h
+++ b/Rollbar/RollbarNotifier.h
@@ -18,7 +18,7 @@
 - (void)processSavedItems;
 
 - (void)logCrashReport:(NSString*)crashReport;
-- (void)log:(NSString*)level message:(NSString*)message exception:(NSException*)exception data:(NSDictionary*)data;
+- (void)log:(NSString*)level message:(NSString*)message exception:(NSException*)exception data:(NSDictionary*)data context:(NSString*)context;
 
 /**
  Sends an item batch in a blocking manner.

--- a/Rollbar/RollbarNotifier.m
+++ b/Rollbar/RollbarNotifier.m
@@ -90,13 +90,13 @@ static BOOL isNetworkReachable = YES;
 }
 
 - (void)logCrashReport:(NSString*)crashReport {
-    NSDictionary *payload = [self buildPayloadWithLevel:self.configuration.crashLevel message:nil exception:nil extra:nil crashReport:crashReport];
+    NSDictionary *payload = [self buildPayloadWithLevel:self.configuration.crashLevel message:nil exception:nil extra:nil crashReport:crashReport context:nil];
     
     [self queuePayload:payload];
 }
 
-- (void)log:(NSString*)level message:(NSString*)message exception:(NSException*)exception data:(NSDictionary*)data {
-    NSDictionary *payload = [self buildPayloadWithLevel:level message:message exception:exception extra:data crashReport:nil];
+- (void)log:(NSString*)level message:(NSString*)message exception:(NSException*)exception data:(NSDictionary*)data context:(NSString*) context {
+    NSDictionary *payload = [self buildPayloadWithLevel:level message:message exception:exception extra:data crashReport:nil context:context];
     
     [self queuePayload:payload];
 }
@@ -230,7 +230,7 @@ static BOOL isNetworkReachable = YES;
     return data;
 }
 
-- (NSDictionary*)buildPayloadWithLevel:(NSString*)level message:(NSString*)message exception:(NSException*)exception extra:(NSDictionary*)extra crashReport:(NSString*)crashReport {
+- (NSDictionary*)buildPayloadWithLevel:(NSString*)level message:(NSString*)message exception:(NSException*)exception extra:(NSDictionary*)extra crashReport:(NSString*)crashReport context:(NSString*)context {
     
     NSDictionary *clientData = [self buildClientData];
     NSDictionary *notifierData = @{@"name": @"rollbar-ios",
@@ -255,6 +255,10 @@ static BOOL isNetworkReachable = YES;
     
     if (personData) {
         data[@"person"] = personData;
+    }
+
+    if (context) {
+        data[@"context"] = context;
     }
     
     return @{@"access_token": self.configuration.accessToken,


### PR DESCRIPTION
We needed to be able to send up the context in the payload, so we massaged the API to open up a new `logWithLevel:message:data:context:` method that will accept a context string.

I didn't want to bloat the API by making every combination of {message, data, context} params for the `*withMessage` methods, so it's only exposed in the `logWithLevel` group of methods.