### PR TITLE
Revert "Fix umbrella header errors for Carthage support"

### DIFF
--- a/Rollbar.xcodeproj/project.pbxproj
+++ b/Rollbar.xcodeproj/project.pbxproj
@@ -96,7 +96,6 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		289DD6CB1DB6DE54004C03D1 /* Rollbar.modulemap */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = "sourcecode.module-map"; path = Rollbar.modulemap; sourceTree = "<group>"; };
 		343AB4521CC9AAE600962943 /* Rollbar.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Rollbar.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		343AB4541CC9AAE600962943 /* RollbarFramework.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RollbarFramework.h; sourceTree = "<group>"; };
 		343AB4561CC9AAE600962943 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -165,7 +164,6 @@
 			children = (
 				343AB4541CC9AAE600962943 /* RollbarFramework.h */,
 				343AB4561CC9AAE600962943 /* Info.plist */,
-				289DD6CB1DB6DE54004C03D1 /* Rollbar.modulemap */,
 			);
 			path = RollbarFramework;
 			sourceTree = "<group>";
@@ -537,7 +535,6 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MODULEMAP_FILE = RollbarFramework/Rollbar.modulemap;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.rollbar.Rollbar;
 				PRODUCT_NAME = Rollbar;
@@ -572,7 +569,6 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MODULEMAP_FILE = RollbarFramework/Rollbar.modulemap;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = com.rollbar.Rollbar;
 				PRODUCT_NAME = Rollbar;

--- a/RollbarFramework/Rollbar.modulemap
+++ b/RollbarFramework/Rollbar.modulemap
@@ -1,6 +1,0 @@
-framework module Rollbar {
-    umbrella header "RollbarFramework.h"
-
-    export *
-    module * { export * }
-}

--- a/RollbarFramework/RollbarFramework.h
+++ b/RollbarFramework/RollbarFramework.h
@@ -8,10 +8,10 @@ FOUNDATION_EXPORT const unsigned char RollbarFrameworkVersionString[];
 
 @import CrashReporter;
 
-#import <Rollbar/Rollbar.h>
-#import <Rollbar/RollbarNotifier.h>
-#import <Rollbar/RollbarConfiguration.h>
-#import <Rollbar/RollbarThread.h>
-#import <Rollbar/RollbarFileReader.h>
-#import <Rollbar/RollbarReachability.h>
-#import <Rollbar/RollbarLogger.h>
+#import <RollbarFramework/Rollbar.h>
+#import <RollbarFramework/RollbarNotifier.h>
+#import <RollbarFramework/RollbarConfiguration.h>
+#import <RollbarFramework/RollbarThread.h>
+#import <RollbarFramework/RollbarFileReader.h>
+#import <RollbarFramework/RollbarReachability.h>
+#import <RollbarFramework/RollbarLogger.h>


### PR DESCRIPTION
Reverts rollbar/rollbar-ios#31

Reverting until I can get the umbrella header working for Carthage. PLCrashreporter doesn't really work with Carthage so I'm considering switching to KSCrash.