### PR TITLE
Issue 38 Resolve atomic / nonatomic warnings

### DIFF
--- a/Rollbar/RollbarConfiguration.h
+++ b/Rollbar/RollbarConfiguration.h
@@ -25,12 +25,12 @@
 
 - (NSDictionary *)customData;
 
-@property (atomic, copy) NSString *accessToken;
-@property (atomic, copy) NSString *environment;
-@property (atomic, copy) NSString *endpoint;
-@property (atomic, copy) NSString *crashLevel;
-@property (readonly, atomic, copy) NSString *personId;
-@property (readonly, atomic, copy) NSString *personUsername;
-@property (readonly, atomic, copy) NSString *personEmail;
+@property (nonatomic, copy) NSString *accessToken;
+@property (nonatomic, copy) NSString *environment;
+@property (nonatomic, copy) NSString *endpoint;
+@property (nonatomic, copy) NSString *crashLevel;
+@property (readonly, nonatomic, copy) NSString *personId;
+@property (readonly, nonatomic, copy) NSString *personUsername;
+@property (readonly, nonatomic, copy) NSString *personEmail;
 
 @end

--- a/Rollbar/RollbarConfiguration.h
+++ b/Rollbar/RollbarConfiguration.h
@@ -25,12 +25,13 @@
 
 - (NSDictionary *)customData;
 
+- (NSString *)personId;
+- (NSString *)personUsername;
+- (NSString *)personEmail;
+
 @property (nonatomic, copy) NSString *accessToken;
 @property (nonatomic, copy) NSString *environment;
 @property (nonatomic, copy) NSString *endpoint;
 @property (nonatomic, copy) NSString *crashLevel;
-@property (readonly, nonatomic, copy) NSString *personId;
-@property (readonly, nonatomic, copy) NSString *personUsername;
-@property (readonly, nonatomic, copy) NSString *personEmail;
 
 @end

--- a/Rollbar/RollbarConfiguration.m
+++ b/Rollbar/RollbarConfiguration.m
@@ -70,11 +70,13 @@ static NSString *configurationFilePath = nil;
 }
 
 - (void)setPersonId:(NSString *)personId username:(NSString *)username email:(NSString *)email {
-    self.personId = personId;
-    self.personUsername = username;
-    self.personEmail = email;
-    
-    [self save];
+    @synchronized (_personId) {
+        self.personId = personId;
+        self.personUsername = username;
+        self.personEmail = email;
+
+        [self save];
+    }
 }
 
 - (void)setValue:(id)value forUndefinedKey:(NSString *)key {
@@ -148,8 +150,26 @@ static NSString *configurationFilePath = nil;
     return result;
 }
 
-
 - (NSDictionary *)customData {
     return [NSDictionary dictionaryWithDictionary:customData];
 }
+
+- (NSString *)personId {
+    @synchronized (_personId) {
+        return _personId;
+    }
+}
+
+- (NSString *)personUsername {
+    @synchronized (_personUsername) {
+        return _personUsername;
+    }
+}
+
+- (NSString *)personEmail {
+    @synchronized (_personEmail) {
+        return _personEmail;
+    }
+}
+
 @end

--- a/Rollbar/RollbarConfiguration.m
+++ b/Rollbar/RollbarConfiguration.m
@@ -18,9 +18,9 @@ static NSString *configurationFilePath = nil;
     NSMutableDictionary *customData;
 }
 
-@property (nonatomic, copy) NSString* personId;
-@property (nonatomic, copy) NSString* personUsername;
-@property (nonatomic, copy) NSString* personEmail;
+@property (nonatomic, copy) NSString *personId;
+@property (nonatomic, copy) NSString *personUsername;
+@property (nonatomic, copy) NSString *personEmail;
 
 @end
 


### PR DESCRIPTION
- Resolves warnings generated by property attributes declared `atomic` which are then inherited by properties which declared as `nonatomic`.
- Minor formatting change.

Resolves #38 