### PR TITLE
Update documentation on import issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,11 @@ Importing with Swift requires the additional step of adding the following lines 
 
 If you have no Bridging Header file, the easiest way to correctly configure it is to add an empty objective-c (`dummy.m` for instance) file. When you do so, XCode will prompt you to create a bridging header file, and will configure your build environment to automatically include those headers in all your Swift files. After creating the Bridging-Header file, you can delete the objective-c file.
 
-Note: You do *not* need to import Rollbar if you're using Swift.
+Import `Rollbar` in your `AppDelegate` class file:
+
+```swift
+import Rollbar
+```
 
 The initialization uses Swift syntax:
 


### PR DESCRIPTION
Not importing `Rollbar` in Swift file might cause `Use of undeclared type 'RollbarConfiguration'` error, even if the header files are added to the bridging file. (https://github.com/rollbar/rollbar-ios/issues/42)

Unless this is resolved in a better way, the documentation should be updated as this could prevent some users from setting up Rollbar.
