### PR TITLE
creating a JSON safe payload

### DIFF
--- a/Rollbar.xcodeproj/project.pbxproj
+++ b/Rollbar.xcodeproj/project.pbxproj
@@ -22,6 +22,10 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
+		1F1681291FAD756100500C45 /* RollbarUtil.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F1681271FAD756100500C45 /* RollbarUtil.h */; };
+		1F16812A1FAD756100500C45 /* RollbarUtil.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F1681281FAD756100500C45 /* RollbarUtil.m */; };
+		1F16812B1FAD757600500C45 /* RollbarUtil.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F1681271FAD756100500C45 /* RollbarUtil.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1F16812C1FAD758000500C45 /* RollbarUtil.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F1681281FAD756100500C45 /* RollbarUtil.m */; };
 		343AB4551CC9AAE600962943 /* RollbarFramework.h in Headers */ = {isa = PBXBuildFile; fileRef = 343AB4541CC9AAE600962943 /* RollbarFramework.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		343AB45A1CC9AAF400962943 /* Rollbar.h in Headers */ = {isa = PBXBuildFile; fileRef = 96D2221218D8E40600933444 /* Rollbar.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		343AB45B1CC9AAF400962943 /* Rollbar.m in Sources */ = {isa = PBXBuildFile; fileRef = 96D2221418D8E40600933444 /* Rollbar.m */; };
@@ -96,6 +100,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		1F1681271FAD756100500C45 /* RollbarUtil.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RollbarUtil.h; sourceTree = "<group>"; };
+		1F1681281FAD756100500C45 /* RollbarUtil.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RollbarUtil.m; sourceTree = "<group>"; };
 		343AB4521CC9AAE600962943 /* Rollbar.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Rollbar.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		343AB4541CC9AAE600962943 /* RollbarFramework.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RollbarFramework.h; sourceTree = "<group>"; };
 		343AB4561CC9AAE600962943 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -227,6 +233,8 @@
 				96AB9E07191B10AE00F0168A /* RollbarReachability.m */,
 				96AB9E14191C0B4000F0168A /* RollbarLogger.h */,
 				96AB9E15191C0B4000F0168A /* RollbarLogger.m */,
+				1F1681271FAD756100500C45 /* RollbarUtil.h */,
+				1F1681281FAD756100500C45 /* RollbarUtil.m */,
 			);
 			path = Rollbar;
 			sourceTree = "<group>";
@@ -270,6 +278,7 @@
 				343AB4661CC9AAF400962943 /* RollbarLogger.h in Headers */,
 				343AB45E1CC9AAF400962943 /* RollbarConfiguration.h in Headers */,
 				343AB4601CC9AAF400962943 /* RollbarThread.h in Headers */,
+				1F16812B1FAD757600500C45 /* RollbarUtil.h in Headers */,
 				343AB4621CC9AAF400962943 /* RollbarFileReader.h in Headers */,
 				343AB45C1CC9AAF400962943 /* RollbarNotifier.h in Headers */,
 			);
@@ -283,6 +292,7 @@
 				96AB9E16191C0B4000F0168A /* RollbarLogger.h in Headers */,
 				966CD46E18F4E4C3005A8F2D /* RollbarThread.h in Headers */,
 				96D75C2A18EA04C6002AA729 /* RollbarConfiguration.h in Headers */,
+				1F1681291FAD756100500C45 /* RollbarUtil.h in Headers */,
 				96DBB59118FDFED8007CFE13 /* RollbarFileReader.h in Headers */,
 				9691838318E4EB0400DE3699 /* Rollbar.h in Headers */,
 			);
@@ -457,6 +467,7 @@
 				343AB4611CC9AAF400962943 /* RollbarThread.m in Sources */,
 				343AB4631CC9AAF400962943 /* RollbarFileReader.m in Sources */,
 				343AB45D1CC9AAF400962943 /* RollbarNotifier.m in Sources */,
+				1F16812C1FAD758000500C45 /* RollbarUtil.m in Sources */,
 				343AB45F1CC9AAF400962943 /* RollbarConfiguration.m in Sources */,
 				343AB45B1CC9AAF400962943 /* Rollbar.m in Sources */,
 				343AB4651CC9AAF400962943 /* RollbarReachability.m in Sources */,
@@ -471,6 +482,7 @@
 				966CD46F18F4E4C3005A8F2D /* RollbarThread.m in Sources */,
 				96DBB59218FDFED8007CFE13 /* RollbarFileReader.m in Sources */,
 				96D2223518D8E51600933444 /* RollbarNotifier.m in Sources */,
+				1F16812A1FAD756100500C45 /* RollbarUtil.m in Sources */,
 				9630826518DCDDC000256154 /* RollbarConfiguration.m in Sources */,
 				96D2221518D8E40600933444 /* Rollbar.m in Sources */,
 				96AB9E09191B10AE00F0168A /* RollbarReachability.m in Sources */,

--- a/Rollbar/RollbarConfiguration.m
+++ b/Rollbar/RollbarConfiguration.m
@@ -8,6 +8,7 @@
 
 #import "RollbarConfiguration.h"
 #import "objc/runtime.h"
+#import "RollbarUtil.h"
 
 static NSString *CONFIGURATION_FILENAME = @"rollbar.config";
 static NSString *DEFAULT_ENDPOINT = @"https://api.rollbar.com/api/1/items/";
@@ -116,6 +117,7 @@ static NSString *configurationFilePath = nil;
             }
         }
         
+        config = [RollbarUtil jsonSafePayloadFromDictionary:config];
         NSData *configJson = [NSJSONSerialization dataWithJSONObject:config options:0 error:nil];
         [configJson writeToFile:configurationFilePath atomically:YES];
     }

--- a/Rollbar/RollbarNotifier.m
+++ b/Rollbar/RollbarNotifier.m
@@ -13,6 +13,7 @@
 #import "RollbarLogger.h"
 #import <UIKit/UIKit.h>
 #include <sys/utsname.h>
+#import "RollbarUtil.h"
 
 
 static NSString *NOTIFIER_VERSION = @"0.2.0";
@@ -102,6 +103,7 @@ static BOOL isNetworkReachable = YES;
 }
 
 - (void)saveQueueState {
+    queueState = [RollbarUtil jsonSafePayloadFromDictionary:queueState];
     NSData *data = [NSJSONSerialization dataWithJSONObject:queueState options:0 error:nil];
     [data writeToFile:stateFilePath atomically:YES];
 }
@@ -291,6 +293,7 @@ static BOOL isNetworkReachable = YES;
 - (void)queuePayload:(NSDictionary*)payload {
     NSFileHandle *fileHandle = [NSFileHandle fileHandleForWritingAtPath:queuedItemsFilePath];
     [fileHandle seekToEndOfFile];
+    payload = [RollbarUtil jsonSafePayloadFromDictionary:payload];
     [fileHandle writeData:[NSJSONSerialization dataWithJSONObject:payload options:0 error:nil]];
     [fileHandle writeData:[@"\n" dataUsingEncoding:NSUTF8StringEncoding]];
     [fileHandle closeFile];
@@ -300,6 +303,7 @@ static BOOL isNetworkReachable = YES;
     NSDictionary *newPayload = @{@"access_token": accessToken,
                                  @"data": itemData};
     
+    newPayload = [RollbarUtil jsonSafePayloadFromDictionary:newPayload];
     NSData *jsonPayload = [NSJSONSerialization dataWithJSONObject:newPayload options:0 error:nil];
     
     BOOL success = [self sendPayload:jsonPayload];

--- a/Rollbar/RollbarUtil.h
+++ b/Rollbar/RollbarUtil.h
@@ -1,0 +1,15 @@
+//
+//  RollbarUtil.h
+//  Rollbar
+//
+//  Created by Freddy Hernandez on 11/3/17.
+//  Copyright © 2017 Rollbar. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface RollbarUtil : NSObject
+
++ (NSMutableDictionary*)jsonSafePayloadFromDictionary:(NSDictionary*)dictionary;
+
+@end

--- a/Rollbar/RollbarUtil.m
+++ b/Rollbar/RollbarUtil.m
@@ -1,0 +1,47 @@
+//
+//  RollbarUtil.m
+//  Rollbar
+//
+//  Created by Freddy Hernandez on 11/3/17.
+//  Copyright © 2017 Rollbar. All rights reserved.
+//
+
+#import "RollbarUtil.h"
+#import "RollbarLogger.h"
+
+@implementation RollbarUtil
+
++ (NSMutableDictionary*)jsonSafePayloadFromDictionary:(NSDictionary*)dictionary {
+    NSMutableDictionary* d = [NSMutableDictionary new];
+    [dictionary enumerateKeysAndObjectsUsingBlock:^(id  _Nonnull key, id  _Nonnull obj, BOOL * _Nonnull stop) {
+        if ([obj isKindOfClass:[NSDictionary class]]) {
+            [d setObject:[self jsonSafePayloadFromDictionary:obj] forKey:key];
+        } else if ([NSJSONSerialization isValidJSONObject:@{key:obj}]) {
+            [d setObject:obj forKey:key];
+        } else if ([obj isKindOfClass:[NSDate class]]) {
+            [d setObject:[obj description] forKey:key];
+        } else if ([obj isKindOfClass:[NSURL class]]) {
+            [d setObject:[obj absoluteString] forKey:key];
+        } else if ([obj isKindOfClass:[NSError class]]) {
+            [d setObject:[self jsonSafePayloadFromDictionary:[obj userInfo]] forKey:key];
+        } else if ([obj isKindOfClass:[NSHTTPURLResponse class]]) {
+            [d setObject:[obj allHeaderFields] forKey:key];
+        } else if ([obj isKindOfClass:[NSData class]]) {
+            NSError* error = nil;
+            NSDictionary* json = [NSJSONSerialization JSONObjectWithData:obj options:kNilOptions error:&error];
+            if (error == nil) {
+                [d setObject:[self jsonSafePayloadFromDictionary:json] forKey:key];
+            } else {
+                RollbarLog(@"There was an error serializing NSData in payload to Rollbar");
+                RollbarLog(@"Error: %@", [error localizedDescription]);
+            }
+        } else {
+            // oops we didn't queue the whole payload
+            RollbarLog(@"There was an error serializing values in payload to Rollbar");
+            RollbarLog(@"Error: %@ can not be serialized by NSJSONSerialization", NSStringFromClass([obj class]));
+        }
+    }];
+    return d;
+}
+
+@end


### PR DESCRIPTION
This is needed in order to prevent exceptions when attempting to use 
```[NSJSONSerialization dataWithJSONObject:...```

Before serializing with `dataWithJSONObject`, every value in the payload dictionary is checked with `isValidJSONObject`. If an object is encountered that fails the test, we attempt to convert that object to something that will pass the `isValidJSONObject` test.

See Apple's Documentation:

https://developer.apple.com/documentation/foundation/nsjsonserialization/1413636-datawithjsonobject

```If obj will not produce valid JSON, an exception is thrown. This exception is thrown prior to parsing and represents a programming error, not an internal error. You should check whether the input will produce valid JSON before calling this method by using isValidJSONObject:.```