### PR TITLE
Fix crash reporting

### DIFF
--- a/Rollbar/Rollbar.h
+++ b/Rollbar/Rollbar.h
@@ -84,6 +84,8 @@
 + (void)critical:(NSString*)message exception:(NSException*)exception data:(NSDictionary*)data;
 + (void)critical:(NSString*)message exception:(NSException*)exception data:(NSDictionary*)data context:(NSString*)context;
 
++ (void)logCrashReport:(NSString*)crashReport;
+
 // Telemetry logging
 
 + (void)recordViewEventForLevel:(RollbarLevel)level element:(NSString *)element;

--- a/Rollbar/Rollbar.m
+++ b/Rollbar/Rollbar.m
@@ -266,6 +266,12 @@ static RollbarNotifier *notifier = nil;
     [notifier log:@"critical" message:nil exception:nil data:data context:nil];
 }
 
+// Crash Report
+
++ (void)logCrashReport:(NSString*)crashReport {
+    [notifier logCrashReport:crashReport];
+}
+
 #pragma mark - Telemetry logging methods
 
 #pragma mark - Dom

--- a/Rollbar/RollbarKSCrashInstallation.m
+++ b/Rollbar/RollbarKSCrashInstallation.m
@@ -27,7 +27,8 @@
 }
 
 - (id<KSCrashReportFilter>)sink {
-    return [[RollbarKSCrashReportSink alloc] init];
+    RollbarKSCrashReportSink *sink = [[RollbarKSCrashReportSink alloc] init];
+    return [sink defaultFilterSet];
 }
 
 - (void)sendAllReports {

--- a/Rollbar/RollbarKSCrashReportSink.h
+++ b/Rollbar/RollbarKSCrashReportSink.h
@@ -11,4 +11,6 @@
 
 @interface RollbarKSCrashReportSink : NSObject <KSCrashReportFilter>
 
+- (id<KSCrashReportFilter>)defaultFilterSet;
+
 @end


### PR DESCRIPTION
We were not capturing the crash reports in the apple format like we are supposed to for the backend so the all crash items were broken, this fixes that