### PR TITLE
Iss104

### DIFF
--- a/Rollbar/RollbarNotifier.m
+++ b/Rollbar/RollbarNotifier.m
@@ -66,7 +66,6 @@ static BOOL isNetworkReachable = YES;
                                 @"retry_count": [NSNumber numberWithUnsignedInt:0]} mutableCopy];
             }
 
-
             // Deals with sending items that have been queued up
             rollbarThread = [[RollbarThread alloc] initWithNotifier:self];
             [rollbarThread start];
@@ -662,6 +661,7 @@ static BOOL isNetworkReachable = YES;
     }
 }
 
+// THIS IS ONLY FOR TESTS, DO NOT ACTUALLY USE THIS METHOD, HENCE BEING "PRIVATE"
 - (NSThread *)_rollbarThread {
     return rollbarThread;
 }

--- a/Rollbar/RollbarNotifier.m
+++ b/Rollbar/RollbarNotifier.m
@@ -66,6 +66,7 @@ static BOOL isNetworkReachable = YES;
                                 @"retry_count": [NSNumber numberWithUnsignedInt:0]} mutableCopy];
             }
 
+
             // Deals with sending items that have been queued up
             rollbarThread = [[RollbarThread alloc] initWithNotifier:self];
             [rollbarThread start];
@@ -418,6 +419,10 @@ static BOOL isNetworkReachable = YES;
 }
 
 - (void)queuePayload:(NSDictionary*)payload {
+    [self performSelector:@selector(queuePayloadOnThread:) onThread:rollbarThread withObject:payload waitUntilDone:NO];
+}
+
+- (void)queuePayloadOnThread:(NSDictionary *)payload {
     NSFileHandle *fileHandle = [NSFileHandle fileHandleForWritingAtPath:queuedItemsFilePath];
     [fileHandle seekToEndOfFile];
     [fileHandle writeData:[NSJSONSerialization dataWithJSONObject:payload options:0 error:nil safe:true]];

--- a/Rollbar/RollbarNotifier.m
+++ b/Rollbar/RollbarNotifier.m
@@ -419,10 +419,10 @@ static BOOL isNetworkReachable = YES;
 }
 
 - (void)queuePayload:(NSDictionary*)payload {
-    [self performSelector:@selector(queuePayloadOnThread:) onThread:rollbarThread withObject:payload waitUntilDone:NO];
+    [self performSelector:@selector(queuePayload_OnlyCallOnThread:) onThread:rollbarThread withObject:payload waitUntilDone:NO];
 }
 
-- (void)queuePayloadOnThread:(NSDictionary *)payload {
+- (void)queuePayload_OnlyCallOnThread:(NSDictionary *)payload {
     NSFileHandle *fileHandle = [NSFileHandle fileHandleForWritingAtPath:queuedItemsFilePath];
     [fileHandle seekToEndOfFile];
     [fileHandle writeData:[NSJSONSerialization dataWithJSONObject:payload options:0 error:nil safe:true]];
@@ -660,6 +660,10 @@ static BOOL isNetworkReachable = YES;
         }
         [[RollbarTelemetry sharedInstance] recordConnectivityEventForLevel:RollbarWarning status:status extraData:@{@"network": networkType}];
     }
+}
+
+- (NSThread *)_rollbarThread {
+    return rollbarThread;
 }
 
 @end

--- a/Rollbar/RollbarTelemetry.m
+++ b/Rollbar/RollbarTelemetry.m
@@ -69,7 +69,7 @@ static dispatch_queue_t globalConcurrentQueue = nil;
  */
 - (void)setCaptureLog:(BOOL)shouldCapture {
     dispatch_async(queue, ^{
-        self.captureLog = shouldCapture;
+        captureLog = shouldCapture;
     });
 }
 

--- a/RollbarTests/RollbarTelemetryTests.m
+++ b/RollbarTests/RollbarTelemetryTests.m
@@ -14,6 +14,10 @@
 
 @end
 
+@interface RollbarNotifier (Tests)
+- (NSThread *)_rollbarThread;
+@end
+
 @implementation RollbarTelemetryTests
 
 - (void)setUp {
@@ -29,6 +33,8 @@
     [super tearDown];
 }
 
+- (void)doNothing {}
+
 - (void)testTelemetryCapture {
     [Rollbar recordNavigationEventForLevel:RollbarInfo from:@"from" to:@"to"];
     [Rollbar recordConnectivityEventForLevel:RollbarInfo status:@"status"];
@@ -37,6 +43,9 @@
     [Rollbar recordErrorEventForLevel:RollbarError exception:[NSException exceptionWithName:@"name" reason:@"reason" userInfo:nil]];
     [Rollbar recordManualEventForLevel:RollbarDebug withData:@{@"data": @"content"}];
     [Rollbar debug:@"Test"];
+
+    // We need to block to ensure the file we are trying to read from has been written to
+    [self performSelector:@selector(doNothing) onThread:[Rollbar.currentNotifier _rollbarThread] withObject:nil waitUntilDone:YES];
 
     NSArray *logItems = RollbarReadLogItemFromFile();
     NSDictionary *item = logItems[0];


### PR DESCRIPTION
Fixes #104 

Two big threading issues:
* The queued item file was definitely being accessed by multiple threads, and there is at least one obvious scenario where the file could be emptied while an unsent item had been written to it due to a race condition.
* Currently none of the public telemetry methods are safe to be called from multiple threads, this manifests most clearly with reachability (monitored on its own thread) and the notifier (our internal thread). So there is a pretty clear race condition in logging reachability change status while trying to serialize an item which can cause a crash. [I am pretty sure that is the cause of the crash in the attached issue]