### PR TITLE
Enable skip install on targets

### DIFF
--- a/Rollbar.xcodeproj/project.pbxproj
+++ b/Rollbar.xcodeproj/project.pbxproj
@@ -1966,7 +1966,7 @@
 				MTL_ENABLE_DEBUG_INFO = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.rollbar.Rollbar;
 				PRODUCT_NAME = Rollbar;
-				SKIP_INSTALL = NO;
+				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALID_ARCHS = "arm64 armv7 armv7s x86_64 i386";
@@ -1998,7 +1998,7 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = com.rollbar.Rollbar;
 				PRODUCT_NAME = Rollbar;
-				SKIP_INSTALL = NO;
+				SKIP_INSTALL = YES;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALID_ARCHS = "arm64 armv7 armv7s x86_64 i386";
 				VERSIONING_SYSTEM = "apple-generic";
@@ -2138,7 +2138,7 @@
 				PRIVATE_HEADERS_FOLDER_PATH = /usr/local/include;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PUBLIC_HEADERS_FOLDER_PATH = "$(PROJECT_NAME)Headers";
-				SKIP_INSTALL = NO;
+				SKIP_INSTALL = YES;
 				STRIP_STYLE = "non-global";
 				VALID_ARCHS = "arm64 armv7 armv7s i386 x86_64";
 			};
@@ -2162,7 +2162,7 @@
 				PRIVATE_HEADERS_FOLDER_PATH = /usr/local/include;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PUBLIC_HEADERS_FOLDER_PATH = "$(PROJECT_NAME)Headers";
-				SKIP_INSTALL = NO;
+				SKIP_INSTALL = YES;
 				STRIP_STYLE = "non-global";
 				VALID_ARCHS = "arm64 armv7 armv7s i386 x86_64";
 			};


### PR DESCRIPTION
When I was generating an iOS App archive from my application, after integrating [rollbar-react-native](https://github.com/rollbar/rollbar-react-native) I faced an issue similar to this one [here](https://stackoverflow.com/questions/10715211/cannot-generate-ios-app-archive-in-xcode/10727504#10727504) where it generates an archive which appears under 'Other Items' like in [this issue](https://stackoverflow.com/questions/47103464/archive-in-xcode-appears-under-other-items). 

Looking through all my dependencies I tracked down the issue to the rollbar-ios project having it's target's 'skip install' flag being false. I have been able to fix the issue with my project and this change just provides the same behaviour so that when the rollbar-react-native project pulls in this dependency this will be set by default.

I don't know if there are any reasons why this is set to NO at the moment, and maybe it is for a reason but I look forward to seeing if this change is acceptable.

Cheers