### PR TITLE
Enable sending complete JSON payloads, as proxy for other SDKs

### DIFF
--- a/Rollbar/Rollbar.h
+++ b/Rollbar/Rollbar.h
@@ -80,6 +80,10 @@
 
 + (void)logCrashReport:(NSString*)crashReport;
 
+// Send JSON payload
+
++ (void)sendJsonPayload:(NSData*)payload;
+
 // Telemetry logging
 
 + (void)recordViewEventForLevel:(RollbarLevel)level element:(NSString *)element;

--- a/Rollbar/Rollbar.m
+++ b/Rollbar/Rollbar.m
@@ -21,20 +21,20 @@ static RollbarNotifier *notifier = nil;
 }
 
 + (void)initWithAccessToken:(NSString *)accessToken {
-    
+
     [Rollbar initWithAccessToken:accessToken configuration:nil];
 }
 
 + (void)initWithAccessToken:(NSString *)accessToken
               configuration:(RollbarConfiguration*)configuration {
-    
+
     [Rollbar initWithAccessToken:accessToken configuration:configuration enableCrashReporter:YES];
 }
 
 + (void)initWithAccessToken:(NSString *)accessToken
               configuration:(RollbarConfiguration*)configuration
         enableCrashReporter:(BOOL)enable {
-    
+
     [RollbarTelemetry sharedInstance]; // Load saved data, if any
     if (notifier) {
         RollbarLog(@"Rollbar has already been initialized.");
@@ -46,7 +46,7 @@ static RollbarNotifier *notifier = nil;
         if (enable) {
             [Rollbar enableCrashReporter];
         }
-        
+
         [notifier.configuration save];
     }
 }
@@ -70,14 +70,14 @@ static RollbarNotifier *notifier = nil;
 
 + (void)log:(RollbarLevel)level
     message:(NSString*)message {
-    
+
     [Rollbar log:level message:message exception:nil];
 }
 
 + (void)log:(RollbarLevel)level
     message:(NSString*)message
   exception:(NSException*)exception {
-    
+
     [Rollbar log:level message:message exception:exception data:nil];
 }
 
@@ -85,7 +85,7 @@ static RollbarNotifier *notifier = nil;
     message:(NSString*)message
   exception:(NSException*)exception
        data:(NSDictionary*)data {
-    
+
     [Rollbar log:level message:message exception:exception data:data context:nil];
 }
 
@@ -94,7 +94,7 @@ static RollbarNotifier *notifier = nil;
   exception:(NSException*)exception
        data:(NSDictionary*)data
     context:(NSString*)context {
-    
+
     [notifier log:RollbarStringFromLevel(level)
           message:message
         exception:exception
@@ -224,6 +224,10 @@ static RollbarNotifier *notifier = nil;
             data:(NSDictionary*)data
          context:(NSString*)context {
     [Rollbar log:RollbarCritical message:message exception:exception data:data context:context];
+}
+
++ (void)sendJsonPayload:(NSData*)payload {
+    [notifier sendPayload:payload];
 }
 
 #pragma mark - Deprecated logging methods

--- a/Rollbar/RollbarNotifier.h
+++ b/Rollbar/RollbarNotifier.h
@@ -20,18 +20,28 @@
 
 /**
  Sends an item batch in a blocking manner.
- 
+
  @param payload an item to send
  @param nextOffset the offset in the item queue file of the
  item immediately after this batch. If the send is successful
  or the retry limit is hit, nextOffset will be saved to the
  queueState as the offset to use for the next batch
- 
+
  @return YES if this batch should be discarded if it was
  successful or a retry limit was hit. Otherwise NO is returned if this
  batch should be retried.
  */
 - (BOOL)sendItem:(NSDictionary*)payload nextOffset:(NSUInteger)nextOffset;
+
+
+/**
+ Sends a fully composed JSON payload.
+
+ @param payload complete Rollbar payload as JSON string
+
+ @return YES if successful. NO if not.
+ */
+- (BOOL)sendPayload:(NSData*)payload;
 
 // Update configuration methods
 - (void)updateAccessToken:(NSString*)accessToken configuration:(RollbarConfiguration *)configuration isRoot:(BOOL)isRoot;


### PR DESCRIPTION
The public interface has been updated to use `sendJsonPayload()` instead of `send()`. This is meant to be consistent with https://github.com/rollbar/rollbar.js/pull/724 as well as address the comments here.