### PR TITLE
in preparation to v1.6.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,17 @@
 
 The change log has moved to this repo's [GitHub Releases Page](https://github.com/rollbar/rollbar-ios/releases).
 
+**1.6.0**
+
+- resolve #157: Ability to customize client.ios.code_version
+- resolve #155: Enable sending complete JSON payloads, as proxy for other SDKs
+
 **1.5.2**
+
 - resolve #150: Crash during payload strings truncation
 
 **1.5.0**
+
 - Change how the raw string for crash reports is truncated
 - Finish converting to the /item/ api endpoint. Note that the default endpoint has changed, so if
   you were changing this configuration parameter, you should make sure that whatever you are using

--- a/Rollbar.podspec
+++ b/Rollbar.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "Rollbar"
-  s.version      = "1.5.2"
+  s.version      = "1.6.0"
   s.summary      = "Objective-C library for crash reporting and logging with Rollbar."
   s.description  = <<-DESC
     Find, fix, and resolve errors with Rollbar.
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
   s.author             = { "Rollbar" => "support@rollbar.com" }
   s.social_media_url   = "http://twitter.com/rollbar"
   s.platform           = :ios, "7.0"
-  s.source             = { :git => "https://github.com/rollbar/rollbar-ios.git", :tag => "v1.5.2", :submodules => true}
+  s.source             = { :git => "https://github.com/rollbar/rollbar-ios.git", :tag => "v1.6.0", :submodules => true}
 
   s.source_files       =  'KSCrash/Source/KSCrash/**/*.{m,h,mm,c,cpp}',
                           'Rollbar/*.{h,m}'

--- a/Rollbar/RollbarConfiguration.m
+++ b/Rollbar/RollbarConfiguration.m
@@ -6,7 +6,7 @@
 #import "RollbarTelemetry.h"
 
 static NSString *NOTIFIER_NAME = @"rollbar-ios";
-static NSString *NOTIFIER_VERSION = @"1.5.2";
+static NSString *NOTIFIER_VERSION = @"1.6.0";
 static NSString *FRAMEWORK = @"ios";
 static NSString *CONFIGURATION_FILENAME = @"rollbar.config";
 static NSString *DEFAULT_ENDPOINT = @"https://api.rollbar.com/api/1/item/";


### PR DESCRIPTION
**1.6.0**

- resolve #157: Ability to customize client.ios.code_version
- resolve #155: Enable sending complete JSON payloads, as proxy for other SDKs
