### PR TITLE
Release candidate: v1.8.0-alpha6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ Pods
 Dist/
 
 *.swp
+
+build/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,8 +39,9 @@ The change log has moved to this repo's [GitHub Releases Page](https://github.co
 - fix: resolve #171: Fix build errors during cocoapods' trunk push
 - docs: resolve #175: Create a sample app - macOSAppWithRollbarCocoaPod.
 - docs: resolve #179: Create a sample app - iOSAppWithRollbarCocoaPod.
-- chore: ref #181: Create Rollbar-iOS-UniversalDistribution aggregate build target.
-
+- chore: resolve #181: Create Rollbar-iOS-UniversalDistribution aggregate build target.
+- chore: resolve #182: Create RollbarKit-iOS-UniversalDistribution aggregate build target.
+- chore: resolve #183: Modify all the new build targets to produce build results based on $(PRODUCT_NAME) instead of $(TARGET_NAME).
 
 **1.7.0**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,8 @@ The change log has moved to this repo's [GitHub Releases Page](https://github.co
 - feat: resolve #176: Add sandboxing status detection to RollbarCachesDirectory.
 - fix: resolve #171: Fix build errors during cocoapods' trunk push
 - docs: resolve #175: Create a sample app - macOSAppWithRollbarCocoaPod.
-- docs: ref #179: Create a sample app - iOSAppWithRollbarCocoaPod.
+- docs: resolve #179: Create a sample app - iOSAppWithRollbarCocoaPod.
+- chore: ref #181: Create Rollbar-iOS-UniversalDistribution aggregate build target.
 
 
 **1.7.0**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ The change log has moved to this repo's [GitHub Releases Page](https://github.co
 - chore: resolve #181: Create Rollbar-iOS-UniversalDistribution aggregate build target.
 - chore: resolve #182: Create RollbarKit-iOS-UniversalDistribution aggregate build target.
 - chore: resolve #183: Modify all the new build targets to produce build results based on $(PRODUCT_NAME) instead of $(TARGET_NAME).
+- chore: resolve #184: Create RollbarSDKReleaseDistribution build target.
 
 **1.7.0**
 

--- a/Rollbar.xcodeproj/project.pbxproj
+++ b/Rollbar.xcodeproj/project.pbxproj
@@ -6,6 +6,20 @@
 	objectVersion = 51;
 	objects = {
 
+/* Begin PBXAggregateTarget section */
+		55C8E6F022D9414D00A4ACAF /* Rollbar-iOS-UniversalDistribution */ = {
+			isa = PBXAggregateTarget;
+			buildConfigurationList = 55C8E6F322D9414D00A4ACAF /* Build configuration list for PBXAggregateTarget "Rollbar-iOS-UniversalDistribution" */;
+			buildPhases = (
+				55C8E6F422D941EB00A4ACAF /* ShellScript */,
+			);
+			dependencies = (
+			);
+			name = "Rollbar-iOS-UniversalDistribution";
+			productName = "Rollbar-iOS-UniversalDistribution";
+		};
+/* End PBXAggregateTarget section */
+
 /* Begin PBXBuildFile section */
 		552C3BF022D3E76D00F97C88 /* RollbarFramework.h in Headers */ = {isa = PBXBuildFile; fileRef = 343AB4541CC9AAE600962943 /* RollbarFramework.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		552C3BF122D3E76E00F97C88 /* RollbarFramework.h in Headers */ = {isa = PBXBuildFile; fileRef = 343AB4541CC9AAE600962943 /* RollbarFramework.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -2360,6 +2374,9 @@
 					55454BC222C6A9CC00D4A414 = {
 						CreatedOnToolsVersion = 10.2.1;
 					};
+					55C8E6F022D9414D00A4ACAF = {
+						CreatedOnToolsVersion = 10.2.1;
+					};
 				};
 			};
 			buildConfigurationList = 96D2220518D8E40600933444 /* Build configuration list for PBXProject "Rollbar" */;
@@ -2397,6 +2414,7 @@
 				55454BA622C6A97700D4A414 /* RollbarKit-iOSTests */,
 				55454BBA22C6A9CC00D4A414 /* RollbarKit-macOS */,
 				55454BC222C6A9CC00D4A414 /* RollbarKit-macOSTests */,
+				55C8E6F022D9414D00A4ACAF /* Rollbar-iOS-UniversalDistribution */,
 			);
 		};
 /* End PBXProject section */
@@ -2435,6 +2453,26 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		55C8E6F422D941EB00A4ACAF /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "# define build configuration for this target\nCONFIGURATION=Release\n\n# define output folder environment variable\nUNIVERSAL_OUTPUTFOLDER=${BUILD_DIR}/${CONFIGURATION}-iOS-universal\n\n# Step 1. Build Device and Simulator versions\nxcodebuild -target Rollbar-iOS ONLY_ACTIVE_ARCH=NO -configuration ${CONFIGURATION} -sdk iphoneos  BUILD_DIR=\"${BUILD_DIR}\" BUILD_ROOT=\"${BUILD_ROOT}\"\nxcodebuild -target Rollbar-iOS -configuration ${CONFIGURATION} -sdk iphonesimulator -arch x86_64 -arch i386 -arch armv7 -arch armv7s -arch arm64 BUILD_DIR=\"${BUILD_DIR}\" BUILD_ROOT=\"${BUILD_ROOT}\"\n\n# make sure the output directory exists\nmkdir -p \"${UNIVERSAL_OUTPUTFOLDER}\"\n\n# Step 2. Create universal binary file using lipo\nlipo -create -output \"${UNIVERSAL_OUTPUTFOLDER}/lib${PROJECT_NAME}-iOS.a\" \"${BUILD_DIR}/${CONFIGURATION}-iOS-iphoneos/lib${PROJECT_NAME}-iOS.a\" \"${BUILD_DIR}/${CONFIGURATION}-iOS-iphonesimulator/lib${PROJECT_NAME}-iOS.a\"\n\n# Last touch. copy the header files. Just for convenience\ncp -R \"${BUILD_DIR}/${CONFIGURATION}-iOS-iphoneos/include\" \"${UNIVERSAL_OUTPUTFOLDER}/\"\n";
+		};
+/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		554549BF22C68DBA00D4A414 /* Sources */ = {
@@ -2905,14 +2943,15 @@
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				CONFIGURATION_BUILD_DIR = "$(BUILD_DIR)/$(CONFIGURATION)-iOS";
-				CONFIGURATION_TEMP_DIR = "$(PROJECT_TEMP_DIR)/$(CONFIGURATION)-iOS";
+				CONFIGURATION_BUILD_DIR = "$(BUILD_DIR)/$(CONFIGURATION)-iOS$(EFFECTIVE_PLATFORM_NAME)";
+				CONFIGURATION_TEMP_DIR = "$(PROJECT_TEMP_DIR)/$(CONFIGURATION)-iOS$(EFFECTIVE_PLATFORM_NAME)";
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				IPHONEOS_DEPLOYMENT_TARGET = "$(IPHONEOS_DEPLOYMENT_TARGET)";
 				MACOSX_DEPLOYMENT_TARGET = "$(MACOSX_DEPLOYMENT_TARGET)";
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
 				OTHER_CFLAGS = "-DTARGET_OS_IPHONE";
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -2932,8 +2971,8 @@
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				CONFIGURATION_BUILD_DIR = "$(BUILD_DIR)/$(CONFIGURATION)-iOS";
-				CONFIGURATION_TEMP_DIR = "$(PROJECT_TEMP_DIR)/$(CONFIGURATION)-iOS";
+				CONFIGURATION_BUILD_DIR = "$(BUILD_DIR)/$(CONFIGURATION)-iOS$(EFFECTIVE_PLATFORM_NAME)";
+				CONFIGURATION_TEMP_DIR = "$(PROJECT_TEMP_DIR)/$(CONFIGURATION)-iOS$(EFFECTIVE_PLATFORM_NAME)";
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				GCC_C_LANGUAGE_STANDARD = gnu11;
@@ -3296,6 +3335,24 @@
 			};
 			name = Release;
 		};
+		55C8E6F122D9414D00A4ACAF /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = LDX6L68VZJ;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Debug;
+		};
+		55C8E6F222D9414D00A4ACAF /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = LDX6L68VZJ;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Release;
+		};
 		96D2222B18D8E40600933444 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -3461,6 +3518,15 @@
 			buildConfigurations = (
 				55454BD022C6A9CC00D4A414 /* Debug */,
 				55454BD122C6A9CC00D4A414 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		55C8E6F322D9414D00A4ACAF /* Build configuration list for PBXAggregateTarget "Rollbar-iOS-UniversalDistribution" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				55C8E6F122D9414D00A4ACAF /* Debug */,
+				55C8E6F222D9414D00A4ACAF /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Rollbar.xcodeproj/project.pbxproj
+++ b/Rollbar.xcodeproj/project.pbxproj
@@ -18,6 +18,19 @@
 			name = "Rollbar-iOS-UniversalDistribution";
 			productName = "Rollbar-iOS-UniversalDistribution";
 		};
+		55C8E6F522DCF75A00A4ACAF /* RollbarKit-iOS-UniversalDistribution */ = {
+			isa = PBXAggregateTarget;
+			buildConfigurationList = 55C8E6F622DCF75B00A4ACAF /* Build configuration list for PBXAggregateTarget "RollbarKit-iOS-UniversalDistribution" */;
+			buildPhases = (
+				55C8E6FB22DCFBC200A4ACAF /* ShellScript */,
+			);
+			dependencies = (
+				55C8E6FF22DD1ECD00A4ACAF /* PBXTargetDependency */,
+				55C8E6FA22DCF76E00A4ACAF /* PBXTargetDependency */,
+			);
+			name = "RollbarKit-iOS-UniversalDistribution";
+			productName = "RollbarKit-iOS-UniversalDistribution";
+		};
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
@@ -455,10 +468,10 @@
 		55454B9422C69E2B00D4A414 /* Punycode.h in Headers */ = {isa = PBXBuildFile; fileRef = B54F1A0B1FDA6CA600A6AB0C /* Punycode.h */; };
 		55454B9522C69E2B00D4A414 /* Fallthrough.h in Headers */ = {isa = PBXBuildFile; fileRef = B54F1A0C1FDA6CA600A6AB0C /* Fallthrough.h */; };
 		55454B9622C69E2B00D4A414 /* LLVM.h in Headers */ = {isa = PBXBuildFile; fileRef = B54F1A0D1FDA6CA600A6AB0C /* LLVM.h */; };
-		55454BA822C6A97700D4A414 /* RollbarKit_iOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 55454B9F22C6A97600D4A414 /* RollbarKit_iOS.framework */; };
+		55454BA822C6A97700D4A414 /* Rollbar.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 55454B9F22C6A97600D4A414 /* Rollbar.framework */; };
 		55454BAD22C6A97700D4A414 /* RollbarKit_iOSTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 55454BAC22C6A97700D4A414 /* RollbarKit_iOSTests.m */; };
 		55454BAF22C6A97700D4A414 /* RollbarKit_iOS.h in Headers */ = {isa = PBXBuildFile; fileRef = 55454BA122C6A97600D4A414 /* RollbarKit_iOS.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		55454BC422C6A9CC00D4A414 /* RollbarKit_macOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 55454BBB22C6A9CC00D4A414 /* RollbarKit_macOS.framework */; };
+		55454BC422C6A9CC00D4A414 /* Rollbar.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 55454BBB22C6A9CC00D4A414 /* Rollbar.framework */; };
 		55454BC922C6A9CC00D4A414 /* RollbarKit_macOSTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 55454BC822C6A9CC00D4A414 /* RollbarKit_macOSTests.m */; };
 		55454BCB22C6A9CC00D4A414 /* RollbarKit_macOS.h in Headers */ = {isa = PBXBuildFile; fileRef = 55454BBD22C6A9CC00D4A414 /* RollbarKit_macOS.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		55454BD222C6AB2500D4A414 /* RollbarJSONFriendlyProtocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 55143D98215016A100761B20 /* RollbarJSONFriendlyProtocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -910,6 +923,20 @@
 			remoteGlobalIDString = 55454BBA22C6A9CC00D4A414;
 			remoteInfo = "RollbarKit-macOS";
 		};
+		55C8E6F922DCF76E00A4ACAF /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 96D2220218D8E40600933444 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 55C8E6F022D9414D00A4ACAF;
+			remoteInfo = "Rollbar-iOS-UniversalDistribution";
+		};
+		55C8E6FE22DD1ECD00A4ACAF /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 96D2220218D8E40600933444 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 55454B9E22C6A97600D4A414;
+			remoteInfo = "RollbarKit-iOS";
+		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -943,19 +970,19 @@
 		55143D9A21501E5B00761B20 /* RollbarJSONFriendlyObject.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RollbarJSONFriendlyObject.h; sourceTree = "<group>"; };
 		55143D9D21501E8E00761B20 /* RollbarJSONFriendlyObject.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RollbarJSONFriendlyObject.m; sourceTree = "<group>"; };
 		55143DA02151A83D00761B20 /* RollbarDeploysTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RollbarDeploysTests.m; sourceTree = "<group>"; };
-		554549C322C68DBA00D4A414 /* libRollbar-iOS.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libRollbar-iOS.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		554549C322C68DBA00D4A414 /* libRollbar.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libRollbar.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		554549C522C68DBA00D4A414 /* Rollbar_iOS.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Rollbar_iOS.h; sourceTree = "<group>"; };
 		554549C622C68DBA00D4A414 /* Rollbar_iOS.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = Rollbar_iOS.m; sourceTree = "<group>"; };
-		554549DD22C68E8F00D4A414 /* libRollbar-macOS.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libRollbar-macOS.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		554549DD22C68E8F00D4A414 /* libRollbar.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libRollbar.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		554549DF22C68E8F00D4A414 /* Rollbar_macOS.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Rollbar_macOS.h; sourceTree = "<group>"; };
 		554549E122C68E8F00D4A414 /* Rollbar_macOS.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = Rollbar_macOS.m; sourceTree = "<group>"; };
-		55454B9F22C6A97600D4A414 /* RollbarKit_iOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = RollbarKit_iOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		55454B9F22C6A97600D4A414 /* Rollbar.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Rollbar.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		55454BA122C6A97600D4A414 /* RollbarKit_iOS.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RollbarKit_iOS.h; sourceTree = "<group>"; };
 		55454BA222C6A97700D4A414 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		55454BA722C6A97700D4A414 /* RollbarKit-iOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "RollbarKit-iOSTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		55454BAC22C6A97700D4A414 /* RollbarKit_iOSTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RollbarKit_iOSTests.m; sourceTree = "<group>"; };
 		55454BAE22C6A97700D4A414 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		55454BBB22C6A9CC00D4A414 /* RollbarKit_macOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = RollbarKit_macOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		55454BBB22C6A9CC00D4A414 /* Rollbar.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Rollbar.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		55454BBD22C6A9CC00D4A414 /* RollbarKit_macOS.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RollbarKit_macOS.h; sourceTree = "<group>"; };
 		55454BBE22C6A9CC00D4A414 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		55454BC322C6A9CC00D4A414 /* RollbarKit-macOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "RollbarKit-macOSTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1207,7 +1234,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				55454BA822C6A97700D4A414 /* RollbarKit_iOS.framework in Frameworks */,
+				55454BA822C6A97700D4A414 /* Rollbar.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1222,7 +1249,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				55454BC422C6A9CC00D4A414 /* RollbarKit_macOS.framework in Frameworks */,
+				55454BC422C6A9CC00D4A414 /* Rollbar.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1328,11 +1355,11 @@
 		96D2220B18D8E40600933444 /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				554549C322C68DBA00D4A414 /* libRollbar-iOS.a */,
-				554549DD22C68E8F00D4A414 /* libRollbar-macOS.a */,
-				55454B9F22C6A97600D4A414 /* RollbarKit_iOS.framework */,
+				554549C322C68DBA00D4A414 /* libRollbar.a */,
+				554549DD22C68E8F00D4A414 /* libRollbar.a */,
+				55454B9F22C6A97600D4A414 /* Rollbar.framework */,
 				55454BA722C6A97700D4A414 /* RollbarKit-iOSTests.xctest */,
-				55454BBB22C6A9CC00D4A414 /* RollbarKit_macOS.framework */,
+				55454BBB22C6A9CC00D4A414 /* Rollbar.framework */,
 				55454BC322C6A9CC00D4A414 /* RollbarKit-macOSTests.xctest */,
 			);
 			name = Products;
@@ -2255,7 +2282,7 @@
 			);
 			name = "Rollbar-iOS";
 			productName = "Rollbar-iOS";
-			productReference = 554549C322C68DBA00D4A414 /* libRollbar-iOS.a */;
+			productReference = 554549C322C68DBA00D4A414 /* libRollbar.a */;
 			productType = "com.apple.product-type.library.static";
 		};
 		554549DC22C68E8F00D4A414 /* Rollbar-macOS */ = {
@@ -2272,7 +2299,7 @@
 			);
 			name = "Rollbar-macOS";
 			productName = "Rollbar-macOS";
-			productReference = 554549DD22C68E8F00D4A414 /* libRollbar-macOS.a */;
+			productReference = 554549DD22C68E8F00D4A414 /* libRollbar.a */;
 			productType = "com.apple.product-type.library.static";
 		};
 		55454B9E22C6A97600D4A414 /* RollbarKit-iOS */ = {
@@ -2290,7 +2317,7 @@
 			);
 			name = "RollbarKit-iOS";
 			productName = "RollbarKit-iOS";
-			productReference = 55454B9F22C6A97600D4A414 /* RollbarKit_iOS.framework */;
+			productReference = 55454B9F22C6A97600D4A414 /* Rollbar.framework */;
 			productType = "com.apple.product-type.framework";
 		};
 		55454BA622C6A97700D4A414 /* RollbarKit-iOSTests */ = {
@@ -2326,7 +2353,7 @@
 			);
 			name = "RollbarKit-macOS";
 			productName = "RollbarKit-macOS";
-			productReference = 55454BBB22C6A9CC00D4A414 /* RollbarKit_macOS.framework */;
+			productReference = 55454BBB22C6A9CC00D4A414 /* Rollbar.framework */;
 			productType = "com.apple.product-type.framework";
 		};
 		55454BC222C6A9CC00D4A414 /* RollbarKit-macOSTests */ = {
@@ -2377,6 +2404,9 @@
 					55C8E6F022D9414D00A4ACAF = {
 						CreatedOnToolsVersion = 10.2.1;
 					};
+					55C8E6F522DCF75A00A4ACAF = {
+						CreatedOnToolsVersion = 10.2.1;
+					};
 				};
 			};
 			buildConfigurationList = 96D2220518D8E40600933444 /* Build configuration list for PBXProject "Rollbar" */;
@@ -2415,6 +2445,7 @@
 				55454BBA22C6A9CC00D4A414 /* RollbarKit-macOS */,
 				55454BC222C6A9CC00D4A414 /* RollbarKit-macOSTests */,
 				55C8E6F022D9414D00A4ACAF /* Rollbar-iOS-UniversalDistribution */,
+				55C8E6F522DCF75A00A4ACAF /* RollbarKit-iOS-UniversalDistribution */,
 			);
 		};
 /* End PBXProject section */
@@ -2470,7 +2501,24 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "# define build configuration for this target\nCONFIGURATION=Release\n\n# define output folder environment variable\nUNIVERSAL_OUTPUTFOLDER=${BUILD_DIR}/${CONFIGURATION}-iOS-universal\n\n# Step 1. Build Device and Simulator versions\nxcodebuild -target Rollbar-iOS ONLY_ACTIVE_ARCH=NO -configuration ${CONFIGURATION} -sdk iphoneos  BUILD_DIR=\"${BUILD_DIR}\" BUILD_ROOT=\"${BUILD_ROOT}\"\nxcodebuild -target Rollbar-iOS -configuration ${CONFIGURATION} -sdk iphonesimulator -arch x86_64 -arch i386 -arch armv7 -arch armv7s -arch arm64 BUILD_DIR=\"${BUILD_DIR}\" BUILD_ROOT=\"${BUILD_ROOT}\"\n\n# make sure the output directory exists\nmkdir -p \"${UNIVERSAL_OUTPUTFOLDER}\"\n\n# Step 2. Create universal binary file using lipo\nlipo -create -output \"${UNIVERSAL_OUTPUTFOLDER}/lib${PROJECT_NAME}-iOS.a\" \"${BUILD_DIR}/${CONFIGURATION}-iOS-iphoneos/lib${PROJECT_NAME}-iOS.a\" \"${BUILD_DIR}/${CONFIGURATION}-iOS-iphonesimulator/lib${PROJECT_NAME}-iOS.a\"\n\n# Last touch. copy the header files. Just for convenience\ncp -R \"${BUILD_DIR}/${CONFIGURATION}-iOS-iphoneos/include\" \"${UNIVERSAL_OUTPUTFOLDER}/\"\n";
+			shellScript = "# define build configuration for this target\nCONFIGURATION=Release\n\n# define output folder environment variable\nUNIVERSAL_OUTPUTFOLDER=${BUILD_DIR}/${CONFIGURATION}-iOS-universal\n\n# build Simulator versions\nxcodebuild -project \"${PROJECT_FILE_PATH}\" -target Rollbar-iOS -configuration ${CONFIGURATION} -sdk iphonesimulator -arch x86_64 -arch i386 -arch armv7 -arch armv7s -arch arm64 BUILD_DIR=\"${BUILD_DIR}\" BUILD_ROOT=\"${BUILD_ROOT}\" OBJROOT=\"${OBJROOT}/DependentBuilds\" SYMROOT=\"${SYMROOT}\" $ACTION\n\n# build Device version\nxcodebuild -project \"${PROJECT_FILE_PATH}\" -target Rollbar-iOS ONLY_ACTIVE_ARCH=NO -configuration ${CONFIGURATION} -sdk iphoneos BUILD_DIR=\"${BUILD_DIR}\" BUILD_ROOT=\"${BUILD_ROOT}\" OBJROOT=\"${OBJROOT}/DependentBuilds\" SYMROOT=\"${SYMROOT}\" $ACTION\n\n# make sure the output directory exists\nmkdir -p \"${UNIVERSAL_OUTPUTFOLDER}\"\n\n# create universal binary file using lipo\nlipo -create \"${BUILD_DIR}/${CONFIGURATION}-iOS-iphoneos/lib${PROJECT_NAME}.a\" \"${BUILD_DIR}/${CONFIGURATION}-iOS-iphonesimulator/lib${PROJECT_NAME}.a\" -output \"${UNIVERSAL_OUTPUTFOLDER}/lib${PROJECT_NAME}.a\" \n\n# Last touch. copy the header files. Just for convenience\ncp -R \"${BUILD_DIR}/${CONFIGURATION}-iOS-iphoneos/include\" \"${UNIVERSAL_OUTPUTFOLDER}/\"\n\ncp -R \"${BUILD_DIR}/${CONFIGURATION}-iOS-iphoneos/usr/local/include\" \"${UNIVERSAL_OUTPUTFOLDER}/\"\n";
+		};
+		55C8E6FB22DCFBC200A4ACAF /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "#PRODUCT_NAME = \"Rollbar\"\nPREBUILT_KIT_LAYOUT=\"${BUILD_ROOT}/Debug-iOS-Kit/Rollbar.framework\"\nKIT_NAME=\"${PRODUCT_NAME}.framework\"\nLIB_NAME=\"lib${PRODUCT_NAME}.a\"\nDIST_DIR=\"${SRCROOT}/Dist/${PRODUCT_NAME}\"\nTARGET_BUILD_DIR=\"${BUILD_ROOT}/${TARGET_NAME}\"\n\n\n# define build configuration for this target\nCONFIGURATION=Release\n\n# define universal static lib output folder environment variable\nUNIVERSAL_LIB_OUTPUTFOLDER=${BUILD_DIR}/${CONFIGURATION}-iOS-universal\n\n# define universal kit output folder environment variable\nUNIVERSAL_KIT_OUTPUTFOLDER=${BUILD_DIR}/${CONFIGURATION}-iOS-Kit-universal\n\n# build Device version of the kit\n#xcodebuild -project \"${PROJECT_FILE_PATH}\" -target RollbarKit-iOS -configuration ${CONFIGURATION} -sdk iphoneos BUILD_DIR=\"${BUILD_DIR}\" BUILD_ROOT=\"${BUILD_ROOT}\" \n\n# make sure the output directory exists\nrm -rf \"${UNIVERSAL_KIT_OUTPUTFOLDER}\"\nmkdir -p \"${UNIVERSAL_KIT_OUTPUTFOLDER}\"\n \n\n#rm -rf \"${UNIVERSAL_KIT_OUTPUTFOLDER}/${KIT_NAME}/Versions/A/${PRODUCT_NAME}\"\n#mkdir -p \"${UNIVERSAL_KIT_OUTPUTFOLDER}/${KIT_NAME}/Versions/A/${PRODUCT_NAME}\"\n\n# copy over over kit/framwork from a dependency kit debug build\n# while using proper kit name (product name based):\ncp -p -r \"${PREBUILT_KIT_LAYOUT}\" \"${UNIVERSAL_KIT_OUTPUTFOLDER}/${KIT_NAME}\"\n\n# copy over prebuilt universal static library but properly named for the kit:\ncp -a \"${UNIVERSAL_LIB_OUTPUTFOLDER}/${LIB_NAME}\" \"${UNIVERSAL_KIT_OUTPUTFOLDER}/${KIT_NAME}/${PRODUCT_NAME}\"\n\n\n# Last touch. copy the header files. Just for convenience\n#cp -R \"${BUILD_DIR}/${CONFIGURATION}-iOS-iphoneos/include\" \"${UNIVERSAL_OUTPUTFOLDER}/\"\n\n#cp -R \"${BUILD_DIR}/${CONFIGURATION}-iOS-iphoneos/usr/local/include\" \"${UNIVERSAL_OUTPUTFOLDER}/include/Rollbar/\"\n\n\n\n\n\n\n\n\n\n\n\n#set -e\n#set +u\n# Avoid recursively calling this script.\n#if [[ $SF_MASTER_SCRIPT_RUNNING ]]\n#then\n#exit 0\n#fi\n#set -u\n#export SF_MASTER_SCRIPT_RUNNING=1\n\n#SF_TARGET_NAME=${PROJECT_NAME}\n#SF_EXECUTABLE_PATH=\"lib${SF_TARGET_NAME}.a\"\n#SF_WRAPPER_NAME=\"${SF_TARGET_NAME}.framework\"\n#DIST_DIR=\"${SRCROOT}/Dist/${SF_TARGET_NAME}\"\n\n# The following conditionals come from\n# https://github.com/kstenerud/iOS-Universal-Framework\n\n#if [[ \"$SDK_NAME\" =~ ([A-Za-z]+) ]]\n#then\n#SF_SDK_PLATFORM=${BASH_REMATCH[1]}\n#else\n#echo \"Could not find platform name from SDK_NAME: $SDK_NAME\"\n#exit 1\n#fi\n\n#if [[ \"$SDK_NAME\" =~ ([0-9]+.*$) ]]\n#then\n#SF_SDK_VERSION=${BASH_REMATCH[1]}\n#else\n#echo \"Could not find sdk version from SDK_NAME: $SDK_NAME\"\n#exit 1\n#fi\n\n#if [[ \"$SF_SDK_PLATFORM\" = \"iphoneos\" ]]\n#then\n#SF_OTHER_PLATFORM=iphonesimulator\n#else\n#SF_OTHER_PLATFORM=iphoneos\n#fi\n\n#if [[ \"$BUILT_PRODUCTS_DIR\" =~ (.*)$SF_SDK_PLATFORM$ ]]\n#then\n#SF_OTHER_BUILT_PRODUCTS_DIR=\"${BASH_REMATCH[1]}${SF_OTHER_PLATFORM}\"\n#else\n#echo \"Could not find platform name from build products directory: #$BUILT_PRODUCTS_DIR\"\n#exit 1\n#fi\n\n# Build the other platform.\n#xcrun xcodebuild -project \"${PROJECT_FILE_PATH}\" -target \"${TARGET_NAME}\" -configuration \"${CONFIGURATION}\" -sdk ${SF_OTHER_PLATFORM}${SF_SDK_VERSION} BUILD_DIR=\"${BUILD_DIR}\" OBJROOT=\"${OBJROOT}/DependentBuilds\" BUILD_ROOT=\"${BUILD_ROOT}\" SYMROOT=\"${SYMROOT}\" $ACTION\n\n# Smash the two static libraries into one fat binary and store it in the .framework\n#xcrun lipo -create \"${BUILT_PRODUCTS_DIR}/${SF_EXECUTABLE_PATH}\" \"${SF_OTHER_BUILT_PRODUCTS_DIR}/${SF_EXECUTABLE_PATH}\" -output \"${BUILT_PRODUCTS_DIR}/${SF_WRAPPER_NAME}/Versions/A/${SF_TARGET_NAME}\"\n\n# Copy the binary to the other architecture folder to have a complete framework in both.\n#cp -a \"${BUILT_PRODUCTS_DIR}/${SF_WRAPPER_NAME}/Versions/A/${SF_TARGET_NAME}\" \"${SF_OTHER_BUILT_PRODUCTS_DIR}/${SF_WRAPPER_NAME}/Versions/A/${SF_TARGET_NAME}\"\n\n#rm -rf \"${DIST_DIR}\"\n#mkdir -p \"${DIST_DIR}\"\n\n#cp -R \"${BUILT_PRODUCTS_DIR}/${SF_WRAPPER_NAME}\" \"${DIST_DIR}/\"\n# We no longer use PLCrashReporter\n#cp -R \"${SRCROOT}/Vendor/CrashReporter.framework\" \"${DIST_DIR}/\"\n\n#cd \"${SRCROOT}/Dist\"\n#zip -yr \"${SF_TARGET_NAME}.zip\" \"${SF_TARGET_NAME}/\"\n\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -2918,6 +2966,16 @@
 			target = 55454BBA22C6A9CC00D4A414 /* RollbarKit-macOS */;
 			targetProxy = 55454BC522C6A9CC00D4A414 /* PBXContainerItemProxy */;
 		};
+		55C8E6FA22DCF76E00A4ACAF /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 55C8E6F022D9414D00A4ACAF /* Rollbar-iOS-UniversalDistribution */;
+			targetProxy = 55C8E6F922DCF76E00A4ACAF /* PBXContainerItemProxy */;
+		};
+		55C8E6FF22DD1ECD00A4ACAF /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 55454B9E22C6A97600D4A414 /* RollbarKit-iOS */;
+			targetProxy = 55C8E6FE22DD1ECD00A4ACAF /* PBXContainerItemProxy */;
+		};
 /* End PBXTargetDependency section */
 
 /* Begin PBXVariantGroup section */
@@ -2954,7 +3012,7 @@
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_CFLAGS = "-DTARGET_OS_IPHONE";
 				OTHER_LDFLAGS = "-ObjC";
-				PRODUCT_NAME = "$(TARGET_NAME)";
+				PRODUCT_NAME = "$(PRODUCT_NAME)";
 				SKIP_INSTALL = YES;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -2982,7 +3040,7 @@
 				MTL_FAST_MATH = YES;
 				OTHER_CFLAGS = "-DTARGET_OS_IPHONE";
 				OTHER_LDFLAGS = "-ObjC";
-				PRODUCT_NAME = "$(TARGET_NAME)";
+				PRODUCT_NAME = "$(PRODUCT_NAME)";
 				SKIP_INSTALL = YES;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -3008,7 +3066,7 @@
 				MACOSX_DEPLOYMENT_TARGET = "$(MACOSX_DEPLOYMENT_TARGET)";
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
-				PRODUCT_NAME = "$(TARGET_NAME)";
+				PRODUCT_NAME = "$(PRODUCT_NAME)";
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
 			};
@@ -3035,7 +3093,7 @@
 				MACOSX_DEPLOYMENT_TARGET = "$(MACOSX_DEPLOYMENT_TARGET)";
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
-				PRODUCT_NAME = "$(TARGET_NAME)";
+				PRODUCT_NAME = "$(PRODUCT_NAME)";
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
 			};
@@ -3073,8 +3131,8 @@
 				MACOSX_DEPLOYMENT_TARGET = "$(MACOSX_DEPLOYMENT_TARGET)";
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
-				PRODUCT_BUNDLE_IDENTIFIER = "com.rollbar.RollbarKit-iOS";
-				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.rollbar.$(PRODUCT_NAME)";
+				PRODUCT_NAME = "$(PRODUCT_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -3116,8 +3174,8 @@
 				MACOSX_DEPLOYMENT_TARGET = "$(MACOSX_DEPLOYMENT_TARGET)";
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
-				PRODUCT_BUNDLE_IDENTIFIER = "com.rollbar.RollbarKit-iOS";
-				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.rollbar.$(PRODUCT_NAME)";
+				PRODUCT_NAME = "$(PRODUCT_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -3221,8 +3279,8 @@
 				MACOSX_DEPLOYMENT_TARGET = "$(MACOSX_DEPLOYMENT_TARGET)";
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
-				PRODUCT_BUNDLE_IDENTIFIER = "com.rollbar.RollbarKit-macOS";
-				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.rollbar.$(PRODUCT_NAME)";
+				PRODUCT_NAME = "$(PRODUCT_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
@@ -3266,8 +3324,8 @@
 				MACOSX_DEPLOYMENT_TARGET = "$(MACOSX_DEPLOYMENT_TARGET)";
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
-				PRODUCT_BUNDLE_IDENTIFIER = "com.rollbar.RollbarKit-macOS";
-				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.rollbar.$(PRODUCT_NAME)";
+				PRODUCT_NAME = "$(PRODUCT_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
@@ -3353,6 +3411,24 @@
 			};
 			name = Release;
 		};
+		55C8E6F722DCF75B00A4ACAF /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = LDX6L68VZJ;
+				PRODUCT_NAME = Rollbar;
+			};
+			name = Debug;
+		};
+		55C8E6F822DCF75B00A4ACAF /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = LDX6L68VZJ;
+				PRODUCT_NAME = Rollbar;
+			};
+			name = Release;
+		};
 		96D2222B18D8E40600933444 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -3406,6 +3482,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				MACOSX_DEPLOYMENT_TARGET = 10.12;
 				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_NAME = Rollbar;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				USER_HEADER_SEARCH_PATHS = "";
@@ -3458,6 +3535,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				MACOSX_DEPLOYMENT_TARGET = 10.12;
 				ONLY_ACTIVE_ARCH = NO;
+				PRODUCT_NAME = Rollbar;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				USER_HEADER_SEARCH_PATHS = "";
@@ -3527,6 +3605,15 @@
 			buildConfigurations = (
 				55C8E6F122D9414D00A4ACAF /* Debug */,
 				55C8E6F222D9414D00A4ACAF /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		55C8E6F622DCF75B00A4ACAF /* Build configuration list for PBXAggregateTarget "RollbarKit-iOS-UniversalDistribution" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				55C8E6F722DCF75B00A4ACAF /* Debug */,
+				55C8E6F822DCF75B00A4ACAF /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Rollbar.xcodeproj/project.pbxproj
+++ b/Rollbar.xcodeproj/project.pbxproj
@@ -31,6 +31,18 @@
 			name = "RollbarKit-iOS-UniversalDistribution";
 			productName = "RollbarKit-iOS-UniversalDistribution";
 		};
+		55C8E70022DD4DF900A4ACAF /* RollbarSDKReleaseDistributable */ = {
+			isa = PBXAggregateTarget;
+			buildConfigurationList = 55C8E70122DD4DFA00A4ACAF /* Build configuration list for PBXAggregateTarget "RollbarSDKReleaseDistributable" */;
+			buildPhases = (
+				55C8E70822DE361E00A4ACAF /* ShellScript */,
+			);
+			dependencies = (
+				55C8E70722DE313100A4ACAF /* PBXTargetDependency */,
+			);
+			name = RollbarSDKReleaseDistributable;
+			productName = RollbarSDKReleaseDistributable;
+		};
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
@@ -936,6 +948,13 @@
 			proxyType = 1;
 			remoteGlobalIDString = 55454B9E22C6A97600D4A414;
 			remoteInfo = "RollbarKit-iOS";
+		};
+		55C8E70622DE313100A4ACAF /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 96D2220218D8E40600933444 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 55C8E6F522DCF75A00A4ACAF;
+			remoteInfo = "RollbarKit-iOS-UniversalDistribution";
 		};
 /* End PBXContainerItemProxy section */
 
@@ -2407,6 +2426,9 @@
 					55C8E6F522DCF75A00A4ACAF = {
 						CreatedOnToolsVersion = 10.2.1;
 					};
+					55C8E70022DD4DF900A4ACAF = {
+						CreatedOnToolsVersion = 10.2.1;
+					};
 				};
 			};
 			buildConfigurationList = 96D2220518D8E40600933444 /* Build configuration list for PBXProject "Rollbar" */;
@@ -2446,6 +2468,7 @@
 				55454BC222C6A9CC00D4A414 /* RollbarKit-macOSTests */,
 				55C8E6F022D9414D00A4ACAF /* Rollbar-iOS-UniversalDistribution */,
 				55C8E6F522DCF75A00A4ACAF /* RollbarKit-iOS-UniversalDistribution */,
+				55C8E70022DD4DF900A4ACAF /* RollbarSDKReleaseDistributable */,
 			);
 		};
 /* End PBXProject section */
@@ -2518,7 +2541,24 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "#PRODUCT_NAME = \"Rollbar\"\nPREBUILT_KIT_LAYOUT=\"${BUILD_ROOT}/Debug-iOS-Kit/Rollbar.framework\"\nKIT_NAME=\"${PRODUCT_NAME}.framework\"\nLIB_NAME=\"lib${PRODUCT_NAME}.a\"\nDIST_DIR=\"${SRCROOT}/Dist/${PRODUCT_NAME}\"\nTARGET_BUILD_DIR=\"${BUILD_ROOT}/${TARGET_NAME}\"\n\n\n# define build configuration for this target\nCONFIGURATION=Release\n\n# define universal static lib output folder environment variable\nUNIVERSAL_LIB_OUTPUTFOLDER=${BUILD_DIR}/${CONFIGURATION}-iOS-universal\n\n# define universal kit output folder environment variable\nUNIVERSAL_KIT_OUTPUTFOLDER=${BUILD_DIR}/${CONFIGURATION}-iOS-Kit-universal\n\n# build Device version of the kit\n#xcodebuild -project \"${PROJECT_FILE_PATH}\" -target RollbarKit-iOS -configuration ${CONFIGURATION} -sdk iphoneos BUILD_DIR=\"${BUILD_DIR}\" BUILD_ROOT=\"${BUILD_ROOT}\" \n\n# make sure the output directory exists\nrm -rf \"${UNIVERSAL_KIT_OUTPUTFOLDER}\"\nmkdir -p \"${UNIVERSAL_KIT_OUTPUTFOLDER}\"\n \n\n#rm -rf \"${UNIVERSAL_KIT_OUTPUTFOLDER}/${KIT_NAME}/Versions/A/${PRODUCT_NAME}\"\n#mkdir -p \"${UNIVERSAL_KIT_OUTPUTFOLDER}/${KIT_NAME}/Versions/A/${PRODUCT_NAME}\"\n\n# copy over over kit/framwork from a dependency kit debug build\n# while using proper kit name (product name based):\ncp -p -r \"${PREBUILT_KIT_LAYOUT}\" \"${UNIVERSAL_KIT_OUTPUTFOLDER}/${KIT_NAME}\"\n\n# copy over prebuilt universal static library but properly named for the kit:\ncp -a \"${UNIVERSAL_LIB_OUTPUTFOLDER}/${LIB_NAME}\" \"${UNIVERSAL_KIT_OUTPUTFOLDER}/${KIT_NAME}/${PRODUCT_NAME}\"\n\n\n# Last touch. copy the header files. Just for convenience\n#cp -R \"${BUILD_DIR}/${CONFIGURATION}-iOS-iphoneos/include\" \"${UNIVERSAL_OUTPUTFOLDER}/\"\n\n#cp -R \"${BUILD_DIR}/${CONFIGURATION}-iOS-iphoneos/usr/local/include\" \"${UNIVERSAL_OUTPUTFOLDER}/include/Rollbar/\"\n\n\n\n\n\n\n\n\n\n\n\n#set -e\n#set +u\n# Avoid recursively calling this script.\n#if [[ $SF_MASTER_SCRIPT_RUNNING ]]\n#then\n#exit 0\n#fi\n#set -u\n#export SF_MASTER_SCRIPT_RUNNING=1\n\n#SF_TARGET_NAME=${PROJECT_NAME}\n#SF_EXECUTABLE_PATH=\"lib${SF_TARGET_NAME}.a\"\n#SF_WRAPPER_NAME=\"${SF_TARGET_NAME}.framework\"\n#DIST_DIR=\"${SRCROOT}/Dist/${SF_TARGET_NAME}\"\n\n# The following conditionals come from\n# https://github.com/kstenerud/iOS-Universal-Framework\n\n#if [[ \"$SDK_NAME\" =~ ([A-Za-z]+) ]]\n#then\n#SF_SDK_PLATFORM=${BASH_REMATCH[1]}\n#else\n#echo \"Could not find platform name from SDK_NAME: $SDK_NAME\"\n#exit 1\n#fi\n\n#if [[ \"$SDK_NAME\" =~ ([0-9]+.*$) ]]\n#then\n#SF_SDK_VERSION=${BASH_REMATCH[1]}\n#else\n#echo \"Could not find sdk version from SDK_NAME: $SDK_NAME\"\n#exit 1\n#fi\n\n#if [[ \"$SF_SDK_PLATFORM\" = \"iphoneos\" ]]\n#then\n#SF_OTHER_PLATFORM=iphonesimulator\n#else\n#SF_OTHER_PLATFORM=iphoneos\n#fi\n\n#if [[ \"$BUILT_PRODUCTS_DIR\" =~ (.*)$SF_SDK_PLATFORM$ ]]\n#then\n#SF_OTHER_BUILT_PRODUCTS_DIR=\"${BASH_REMATCH[1]}${SF_OTHER_PLATFORM}\"\n#else\n#echo \"Could not find platform name from build products directory: #$BUILT_PRODUCTS_DIR\"\n#exit 1\n#fi\n\n# Build the other platform.\n#xcrun xcodebuild -project \"${PROJECT_FILE_PATH}\" -target \"${TARGET_NAME}\" -configuration \"${CONFIGURATION}\" -sdk ${SF_OTHER_PLATFORM}${SF_SDK_VERSION} BUILD_DIR=\"${BUILD_DIR}\" OBJROOT=\"${OBJROOT}/DependentBuilds\" BUILD_ROOT=\"${BUILD_ROOT}\" SYMROOT=\"${SYMROOT}\" $ACTION\n\n# Smash the two static libraries into one fat binary and store it in the .framework\n#xcrun lipo -create \"${BUILT_PRODUCTS_DIR}/${SF_EXECUTABLE_PATH}\" \"${SF_OTHER_BUILT_PRODUCTS_DIR}/${SF_EXECUTABLE_PATH}\" -output \"${BUILT_PRODUCTS_DIR}/${SF_WRAPPER_NAME}/Versions/A/${SF_TARGET_NAME}\"\n\n# Copy the binary to the other architecture folder to have a complete framework in both.\n#cp -a \"${BUILT_PRODUCTS_DIR}/${SF_WRAPPER_NAME}/Versions/A/${SF_TARGET_NAME}\" \"${SF_OTHER_BUILT_PRODUCTS_DIR}/${SF_WRAPPER_NAME}/Versions/A/${SF_TARGET_NAME}\"\n\n#rm -rf \"${DIST_DIR}\"\n#mkdir -p \"${DIST_DIR}\"\n\n#cp -R \"${BUILT_PRODUCTS_DIR}/${SF_WRAPPER_NAME}\" \"${DIST_DIR}/\"\n# We no longer use PLCrashReporter\n#cp -R \"${SRCROOT}/Vendor/CrashReporter.framework\" \"${DIST_DIR}/\"\n\n#cd \"${SRCROOT}/Dist\"\n#zip -yr \"${SF_TARGET_NAME}.zip\" \"${SF_TARGET_NAME}/\"\n\n";
+			shellScript = "#PRODUCT_NAME = \"Rollbar\"\nPREBUILT_KIT_LAYOUT=\"${BUILD_ROOT}/Release-iOS-Kit-iphoneos/Rollbar.framework\"\nKIT_NAME=\"${PRODUCT_NAME}.framework\"\nLIB_NAME=\"lib${PRODUCT_NAME}.a\"\nDIST_DIR=\"${SRCROOT}/Dist/${PRODUCT_NAME}\"\nTARGET_BUILD_DIR=\"${BUILD_ROOT}/${TARGET_NAME}\"\n\n\n# define build configuration for this target\nCONFIGURATION=Release\n\n# define universal static lib output folder environment variable\nUNIVERSAL_LIB_OUTPUTFOLDER=${BUILD_DIR}/${CONFIGURATION}-iOS-universal\n\n# define universal kit output folder environment variable\nUNIVERSAL_KIT_OUTPUTFOLDER=${BUILD_DIR}/${CONFIGURATION}-iOS-Kit-universal\n\n# build Simulator version of the kit\nxcodebuild -project \"${PROJECT_FILE_PATH}\" -target RollbarKit-iOS -configuration ${CONFIGURATION} -sdk iphonesimulator BUILD_DIR=\"${BUILD_DIR}\" BUILD_ROOT=\"${BUILD_ROOT}\" \n\n# build Device version of the kit\nxcodebuild -project \"${PROJECT_FILE_PATH}\" -target RollbarKit-iOS -configuration ${CONFIGURATION} -sdk iphoneos BUILD_DIR=\"${BUILD_DIR}\" BUILD_ROOT=\"${BUILD_ROOT}\" \n\n# make sure the output directory exists\nrm -rf \"${UNIVERSAL_KIT_OUTPUTFOLDER}\"\nmkdir -p \"${UNIVERSAL_KIT_OUTPUTFOLDER}\"\n \n\n#rm -rf \"${UNIVERSAL_KIT_OUTPUTFOLDER}/${KIT_NAME}/Versions/A/${PRODUCT_NAME}\"\n#mkdir -p \"${UNIVERSAL_KIT_OUTPUTFOLDER}/${KIT_NAME}/Versions/A/${PRODUCT_NAME}\"\n\n# copy over over kit/framwork from a dependency kit debug build\n# while using proper kit name (product name based):\ncp -p -r \"${PREBUILT_KIT_LAYOUT}\" \"${UNIVERSAL_KIT_OUTPUTFOLDER}/${KIT_NAME}\"\n\n# copy over prebuilt universal static library but properly named for the kit:\ncp -a \"${UNIVERSAL_LIB_OUTPUTFOLDER}/${LIB_NAME}\" \"${UNIVERSAL_KIT_OUTPUTFOLDER}/${KIT_NAME}/${PRODUCT_NAME}\"\n\n# Last touch. copy the header files. Just for convenience\n#cp -R \"${BUILD_DIR}/${CONFIGURATION}-iOS-iphoneos/include\" \"${UNIVERSAL_OUTPUTFOLDER}/\"\n\n#cp -R \"${BUILD_DIR}/${CONFIGURATION}-iOS-iphoneos/usr/local/include\" \"${UNIVERSAL_OUTPUTFOLDER}/include/Rollbar/\"\n\n\n\n\n\n\n\n\n\n\n\n#set -e\n#set +u\n# Avoid recursively calling this script.\n#if [[ $SF_MASTER_SCRIPT_RUNNING ]]\n#then\n#exit 0\n#fi\n#set -u\n#export SF_MASTER_SCRIPT_RUNNING=1\n\n#SF_TARGET_NAME=${PROJECT_NAME}\n#SF_EXECUTABLE_PATH=\"lib${SF_TARGET_NAME}.a\"\n#SF_WRAPPER_NAME=\"${SF_TARGET_NAME}.framework\"\n#DIST_DIR=\"${SRCROOT}/Dist/${SF_TARGET_NAME}\"\n\n# The following conditionals come from\n# https://github.com/kstenerud/iOS-Universal-Framework\n\n#if [[ \"$SDK_NAME\" =~ ([A-Za-z]+) ]]\n#then\n#SF_SDK_PLATFORM=${BASH_REMATCH[1]}\n#else\n#echo \"Could not find platform name from SDK_NAME: $SDK_NAME\"\n#exit 1\n#fi\n\n#if [[ \"$SDK_NAME\" =~ ([0-9]+.*$) ]]\n#then\n#SF_SDK_VERSION=${BASH_REMATCH[1]}\n#else\n#echo \"Could not find sdk version from SDK_NAME: $SDK_NAME\"\n#exit 1\n#fi\n\n#if [[ \"$SF_SDK_PLATFORM\" = \"iphoneos\" ]]\n#then\n#SF_OTHER_PLATFORM=iphonesimulator\n#else\n#SF_OTHER_PLATFORM=iphoneos\n#fi\n\n#if [[ \"$BUILT_PRODUCTS_DIR\" =~ (.*)$SF_SDK_PLATFORM$ ]]\n#then\n#SF_OTHER_BUILT_PRODUCTS_DIR=\"${BASH_REMATCH[1]}${SF_OTHER_PLATFORM}\"\n#else\n#echo \"Could not find platform name from build products directory: #$BUILT_PRODUCTS_DIR\"\n#exit 1\n#fi\n\n# Build the other platform.\n#xcrun xcodebuild -project \"${PROJECT_FILE_PATH}\" -target \"${TARGET_NAME}\" -configuration \"${CONFIGURATION}\" -sdk ${SF_OTHER_PLATFORM}${SF_SDK_VERSION} BUILD_DIR=\"${BUILD_DIR}\" OBJROOT=\"${OBJROOT}/DependentBuilds\" BUILD_ROOT=\"${BUILD_ROOT}\" SYMROOT=\"${SYMROOT}\" $ACTION\n\n# Smash the two static libraries into one fat binary and store it in the .framework\n#xcrun lipo -create \"${BUILT_PRODUCTS_DIR}/${SF_EXECUTABLE_PATH}\" \"${SF_OTHER_BUILT_PRODUCTS_DIR}/${SF_EXECUTABLE_PATH}\" -output \"${BUILT_PRODUCTS_DIR}/${SF_WRAPPER_NAME}/Versions/A/${SF_TARGET_NAME}\"\n\n# Copy the binary to the other architecture folder to have a complete framework in both.\n#cp -a \"${BUILT_PRODUCTS_DIR}/${SF_WRAPPER_NAME}/Versions/A/${SF_TARGET_NAME}\" \"${SF_OTHER_BUILT_PRODUCTS_DIR}/${SF_WRAPPER_NAME}/Versions/A/${SF_TARGET_NAME}\"\n\n#DIST_DIR=\"${SRCROOT}/Dist/${PRODUCT_NAME}\"\n#rm -rf \"${DIST_DIR}\"\n#mkdir -p \"${DIST_DIR}\"\n\n#cp -R \"${BUILT_PRODUCTS_DIR}/${SF_WRAPPER_NAME}\" \"${DIST_DIR}/\"\n# We no longer use PLCrashReporter\n#cp -R \"${SRCROOT}/Vendor/CrashReporter.framework\" \"${DIST_DIR}/\"\n\n#cd \"${SRCROOT}/Dist\"\n#zip -yr \"${SF_TARGET_NAME}.zip\" \"${SF_TARGET_NAME}/\"\n\n";
+		};
+		55C8E70822DE361E00A4ACAF /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "# define build configuration for this target\nCONFIGURATION=Release\n\n# build the macOS static lib:\nxcodebuild -project \"${PROJECT_FILE_PATH}\" -target Rollbar-macOS -configuration ${CONFIGURATION} BUILD_DIR=\"${BUILD_DIR}\" BUILD_ROOT=\"${BUILD_ROOT}\" \n\n# build the macOS kit:\nxcodebuild -project \"${PROJECT_FILE_PATH}\" -target RollbarKit-macOS -configuration ${CONFIGURATION} BUILD_DIR=\"${BUILD_DIR}\" BUILD_ROOT=\"${BUILD_ROOT}\" \n\n# prepare Dist folder inside the ${SRCROOT}:\nDIST_DIR=\"${SRCROOT}/Dist\"\nrm -rf \"${DIST_DIR}\"\nmkdir -p \"${DIST_DIR}\"\n\nDIST_PRODUCT_DIR=\"${DIST_DIR}/${PRODUCT_NAME}\"\nmkdir -p \"${DIST_PRODUCT_DIR}\"\n\n# copy all the release build targets results intended for distribution: \n# 1. static libs for iOS\ncp -R \"${BUILD_DIR}/Release-iOS-iphoneos\" \"${DIST_PRODUCT_DIR}/\"\ncp -R \"${BUILD_DIR}/Release-iOS-iphonesimulator\" \"${DIST_PRODUCT_DIR}/\"\ncp -R \"${BUILD_DIR}/Release-iOS-universal\" \"${DIST_PRODUCT_DIR}/\"\n# 2. framework kits for iOS\ncp -R \"${BUILD_DIR}/Release-iOS-Kit-iphoneos\" \"${DIST_PRODUCT_DIR}/\"\ncp -R \"${BUILD_DIR}/Release-iOS-Kit-iphonesimulator\" \"${DIST_PRODUCT_DIR}/\"\ncp -R \"${BUILD_DIR}/Release-iOS-Kit-universal\" \"${DIST_PRODUCT_DIR}/\"\n# 3. static lib for macOS:\ncp -R \"${BUILD_DIR}/Release-macOS\" \"${DIST_PRODUCT_DIR}/\"\n# 4. framework kit for macOS:\ncp -R \"${BUILD_DIR}/Release-macOS-Kit\" \"${DIST_PRODUCT_DIR}/\"\n\n# Zip-up all the content of the ${DIST_PRODUCT_DIR}:\ncd \"${DIST_DIR}\"\nzip -yr \"${PRODUCT_NAME}.zip\" \"${PRODUCT_NAME}/\"\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -2976,6 +3016,11 @@
 			target = 55454B9E22C6A97600D4A414 /* RollbarKit-iOS */;
 			targetProxy = 55C8E6FE22DD1ECD00A4ACAF /* PBXContainerItemProxy */;
 		};
+		55C8E70722DE313100A4ACAF /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 55C8E6F522DCF75A00A4ACAF /* RollbarKit-iOS-UniversalDistribution */;
+			targetProxy = 55C8E70622DE313100A4ACAF /* PBXContainerItemProxy */;
+		};
 /* End PBXTargetDependency section */
 
 /* Begin PBXVariantGroup section */
@@ -3110,7 +3155,7 @@
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
 				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Manual;
-				CONFIGURATION_BUILD_DIR = "$(BUILD_DIR)/$(CONFIGURATION)-iOS-Kit";
+				CONFIGURATION_BUILD_DIR = "$(BUILD_DIR)/$(CONFIGURATION)-iOS-Kit$(EFFECTIVE_PLATFORM_NAME)";
 				CONFIGURATION_TEMP_DIR = "$(PROJECT_TEMP_DIR)/$(CONFIGURATION)-iOS-Kit";
 				CURRENT_PROJECT_VERSION = "$(CURRENT_PROJECT_VERSION)";
 				DEBUG_INFORMATION_FORMAT = dwarf;
@@ -3152,7 +3197,7 @@
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
 				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Manual;
-				CONFIGURATION_BUILD_DIR = "$(BUILD_DIR)/$(CONFIGURATION)-iOS-Kit";
+				CONFIGURATION_BUILD_DIR = "$(BUILD_DIR)/$(CONFIGURATION)-iOS-Kit$(EFFECTIVE_PLATFORM_NAME)";
 				CONFIGURATION_TEMP_DIR = "$(PROJECT_TEMP_DIR)/$(CONFIGURATION)-iOS-Kit";
 				COPY_PHASE_STRIP = NO;
 				CURRENT_PROJECT_VERSION = "$(CURRENT_PROJECT_VERSION)";
@@ -3298,7 +3343,7 @@
 				CLANG_ENABLE_OBJC_WEAK = YES;
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
-				CODE_SIGN_IDENTITY = "-";
+				CODE_SIGN_IDENTITY = "Mac Developer";
 				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
 				CONFIGURATION_BUILD_DIR = "$(BUILD_DIR)/$(CONFIGURATION)-macOS-Kit";
@@ -3429,6 +3474,24 @@
 			};
 			name = Release;
 		};
+		55C8E70222DD4DFA00A4ACAF /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = LDX6L68VZJ;
+				PRODUCT_NAME = "$(PRODUCT_NAME)";
+			};
+			name = Debug;
+		};
+		55C8E70322DD4DFA00A4ACAF /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = LDX6L68VZJ;
+				PRODUCT_NAME = "$(PRODUCT_NAME)";
+			};
+			name = Release;
+		};
 		96D2222B18D8E40600933444 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -3461,6 +3524,7 @@
 				CODE_SIGN_INJECT_BASE_ENTITLEMENTS = NO;
 				COPY_PHASE_STRIP = NO;
 				CURRENT_PROJECT_VERSION = 1.8.0;
+				DEVELOPMENT_TEAM = LDX6L68VZJ;
 				ENABLE_BITCODE = YES;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
@@ -3521,6 +3585,7 @@
 				CODE_SIGN_INJECT_BASE_ENTITLEMENTS = NO;
 				COPY_PHASE_STRIP = YES;
 				CURRENT_PROJECT_VERSION = 1.8.0;
+				DEVELOPMENT_TEAM = LDX6L68VZJ;
 				ENABLE_BITCODE = YES;
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
@@ -3614,6 +3679,15 @@
 			buildConfigurations = (
 				55C8E6F722DCF75B00A4ACAF /* Debug */,
 				55C8E6F822DCF75B00A4ACAF /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		55C8E70122DD4DFA00A4ACAF /* Build configuration list for PBXAggregateTarget "RollbarSDKReleaseDistributable" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				55C8E70222DD4DFA00A4ACAF /* Debug */,
+				55C8E70322DD4DFA00A4ACAF /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Rollbar.xcodeproj/xcshareddata/xcschemes/Rollbar-iOS.xcscheme
+++ b/Rollbar.xcodeproj/xcshareddata/xcschemes/Rollbar-iOS.xcscheme
@@ -15,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "554549C222C68DBA00D4A414"
-               BuildableName = "libRollbar-iOS.a"
+               BuildableName = "libRollbar.a"
                BlueprintName = "Rollbar-iOS"
                ReferencedContainer = "container:Rollbar.xcodeproj">
             </BuildableReference>
@@ -46,7 +46,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "554549C222C68DBA00D4A414"
-            BuildableName = "libRollbar-iOS.a"
+            BuildableName = "libRollbar.a"
             BlueprintName = "Rollbar-iOS"
             ReferencedContainer = "container:Rollbar.xcodeproj">
          </BuildableReference>
@@ -64,7 +64,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "554549C222C68DBA00D4A414"
-            BuildableName = "libRollbar-iOS.a"
+            BuildableName = "libRollbar.a"
             BlueprintName = "Rollbar-iOS"
             ReferencedContainer = "container:Rollbar.xcodeproj">
          </BuildableReference>

--- a/Rollbar/RollbarConfiguration.m
+++ b/Rollbar/RollbarConfiguration.m
@@ -13,7 +13,7 @@ static NSString *FRAMEWORK = @"ios";
 static NSString *NOTIFIER_NAME = @"rollbar-macos";
 static NSString *FRAMEWORK = @"macos";
 #endif
-static NSString *NOTIFIER_VERSION = @"1.8.0";
+static NSString *NOTIFIER_VERSION = @"1.8.0-alpha6";
 static NSString *CONFIGURATION_FILENAME = @"rollbar.config";
 static NSString *DEFAULT_ENDPOINT = @"https://api.rollbar.com/api/1/item/";
 


### PR DESCRIPTION
- feat: ref #168: add support for high sierra 
- feat: ref #45: How about support for macOS?
- feat: resolve #176: Add sandboxing status detection to RollbarCachesDirectory.
- fix: resolve #171: Fix build errors during cocoapods' trunk push
- docs: resolve #175: Create a sample app - macOSAppWithRollbarCocoaPod.
- docs: resolve #179: Create a sample app - iOSAppWithRollbarCocoaPod.
- chore: resolve #181: Create Rollbar-iOS-UniversalDistribution aggregate build target.
- chore: resolve #182: Create RollbarKit-iOS-UniversalDistribution aggregate build target.
- chore: resolve #183: Modify all the new build targets to produce build results based on $(PRODUCT_NAME) instead of $(TARGET_NAME).
- chore: resolve #184: Create RollbarSDKReleaseDistribution build target.
