### PR TITLE
Compile without headermap, to fix header file collisions

### DIFF
--- a/Rollbar.podspec
+++ b/Rollbar.podspec
@@ -15,15 +15,15 @@ Pod::Spec.new do |s|
   s.social_media_url          = "http://twitter.com/rollbar"
   s.ios.deployment_target     = '8.0'
   s.osx.deployment_target     = '10.12'
-  s.source                    = { :git => "https://github.com/rollbar/rollbar-ios.git", 
-                           :tag => "v#{s.version}", 
+  s.source                    = { :git => "https://github.com/rollbar/rollbar-ios.git",
+                           :tag => "v#{s.version}",
                            :submodules => true
                            }
 
   s.source_files        = 'KSCrash/Source/KSCrash/**/*.{m,h,mm,c,cpp}',
-                          
+
                           'Rollbar/*.{h,m}',
-                          
+
                           'Rollbar/Abstraction_Common/*.{h,m}',
                           'Rollbar/Abstraction_DTO/*.{h,m}',
                           'Rollbar/Abstraction_Deploys/*.{h,m}',
@@ -32,7 +32,7 @@ Pod::Spec.new do |s|
 
                           'Rollbar/Notifier/*.{h,m}',
                           'Rollbar/Notifier_DTOs/*.{h,m}',
-                          
+
                           'Rollbar/Deploys/*.{h,m}',
                           'Rollbar/Deploys_DTOs/*.{h,m}'
 
@@ -118,17 +118,21 @@ Pod::Spec.new do |s|
                             'KSCrash/Source/KSCrash/Reporting/Filters/KSCrashReportFilter.h',
                             'KSCrash/Source/KSCrash/Recording/Monitors/KSCrashMonitorType.h'
 
-  s.ios.frameworks = 
+  s.ios.frameworks =
                 "Foundation",
                 "SystemConfiguration",
                 "UIKit",
                 "MessageUI"
-  s.osx.frameworks = 
+  s.osx.frameworks =
                 "Foundation",
                 "SystemConfiguration"
-  s.libraries = 
-                "c++", 
+  s.libraries =
+                "c++",
                 "z"
   s.requires_arc = true
 
+  s.pod_target_xcconfig = {
+    "USE_HEADERMAP" => "NO",
+    "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/Rollbar\""
+  }
 end


### PR DESCRIPTION
Fixes: https://github.com/rollbar/rollbar-ios/issues/244, https://github.com/rollbar/rollbar-ios/issues/239, https://github.com/rollbar/rollbar-react-native/issues/102, https://github.com/rollbar/rollbar-react-native/issues/108, etc. (I'll add references for any more that I find.)

Xcode's headermaps feature is intended to speed up compilation, but doesn't preserve the include search paths order. This causes the wrong header to be used when two components have the same named header, (e.g. "string.h" and "string.h") Unfortunately this setting is on by default.

See the linked issues for examples of how this breaks compile.

This PR turns off the header map feature for rollbar-ios and its submodule KSCrash, without affecting the compile options for the host app or other pods. (There are other ways to enable/disable at a global level, but this setting will take precedence for rollbar-ios.)

The diff also has trimmed extraneous white space, making it harder to scan for the relevant change. The non-whitespace diff is lines 134-137:
```
  s.pod_target_xcconfig = {
    "USE_HEADERMAP" => "NO",
    "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/Rollbar\""
  }
```